### PR TITLE
[skip ci] left_op_right and better logging

### DIFF
--- a/tedana/resources/decision_trees/minimal.json
+++ b/tedana/resources/decision_trees/minimal.json
@@ -36,63 +36,63 @@
             }
         },
         {
-            "functionname": "metric1_greaterthan_metric2",
+            "functionname": "left_op_right",
             "parameters": {
                 "ifTrue": "rejected",
                 "ifFalse": "nochange",
                 "decide_comps": "all",
-                "metric1": "rho",
-                "metric2": "kappa"
+                "op": ">",
+                "left": "rho",
+                "right": "kappa"
             },
             "kwargs": {
                 "log_extra_info": "Reject if Kappa<Rho",
-                "log_extra_report": "",
-                "metric2_scale": 1
+                "log_extra_report": ""
             }
         },
         {
-            "functionname": "metric1_greaterthan_metric2",
+            "functionname": "left_op_right",
             "parameters": {
                 "ifTrue": "rejected",
                 "ifFalse": "nochange",
                 "decide_comps": "all",
-                "metric1": "countsigFS0",
-                "metric2": "countsigFT2"
+                "op": ">",
+                "left": "countsigFS0",
+                "right": "countsigFT2"
             },
             "kwargs": {
                 "log_extra_info": "Reject if countsig_in S0clusters > T2clusters",
-                "log_extra_report": "",
-                "metric2_scale": 1
+                "log_extra_report": ""
             }
         },
         {
-            "functionname": "metric1_greaterthan_metric2",
+            "functionname": "left_op_right",
             "parameters": {
                 "ifTrue": "rejected",
                 "ifFalse": "nochange",
                 "decide_comps": "all",
-                "metric1": "dice_FS0",
-                "metric2": "dice_FT2"
+                "op": ">",
+                "left": "dice_FS0",
+                "right": "dice_FT2"
             },
             "kwargs": {
                 "log_extra_info": "Reject if dice S0>T2",
-                "log_extra_report": "",
-                "metric2_scale": 1
+                "log_extra_report": ""
             }
         },
         {
-            "functionname": "metric1_greaterthan_metric2",
+            "functionname": "left_op_right",
             "parameters": {
                 "ifTrue": "rejected",
                 "ifFalse": "nochange",
                 "decide_comps": "all",
-                "metric1": 0,
-                "metric2": "signal-noise_t"
+                "op": ">",
+                "left": 0,
+                "right": "signal-noise_t"
             },
             "kwargs": {
                 "log_extra_info": "Reject if T2fitdiff_invsout_ICAmap_Tstat<0",
                 "log_extra_report": "",
-                "metric2_scale": 1
             }
         },
         {
@@ -110,18 +110,19 @@
             }
         },
         {
-            "functionname": "metric1_greaterthan_metric2",
+            "functionname": "left_op_right",
             "parameters": {
                 "ifTrue": "accepted",
                 "ifFalse": "nochange",
                 "decide_comps": "provisionalaccept",
-                "metric1": "kappa",
-                "metric2": "rho"
+                "op": ">",
+                "left": "kappa",
+                "right": "rho"
             },
             "kwargs": {
                 "log_extra_info": "If kappa>elbow and kappa>3*rho accept even if rho>elbow",
                 "log_extra_report": "",
-                "metric2_scale": 3
+                "right_scale": 3
             }
         },
         {

--- a/tedana/resources/decision_trees/minimal.json
+++ b/tedana/resources/decision_trees/minimal.json
@@ -92,7 +92,7 @@
             },
             "kwargs": {
                 "log_extra_info": "Reject if T2fitdiff_invsout_ICAmap_Tstat<0",
-                "log_extra_report": "",
+                "log_extra_report": ""
             }
         },
         {

--- a/tedana/resources/decision_trees/minimal.json
+++ b/tedana/resources/decision_trees/minimal.json
@@ -13,6 +13,15 @@
         "signal-noise_t",
         "variance explained"
     ],
+    "intermediate_classifications": [
+        "lowvariance",
+        "provisionalaccept",
+        "provisionalreject"
+    ],
+    "classification_tags": [
+        "Likely BOLD",
+        "Low variance"
+    ],
     "nodes": [
         {
             "functionname": "manual_classify",
@@ -135,7 +144,7 @@
         {
             "functionname": "variance_lessthan_thresholds",
             "parameters": {
-                "ifTrue": "ignored",
+                "ifTrue": "lowvariance",
                 "ifFalse": "nochange",
                 "decide_comps": [
                     "provisionalreject",

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -365,7 +365,7 @@ def left_op_right(
             val2 = comptable.loc[comps2use, right]
         else:
             val2 = right  # should be a fixed number
-        decision_boolean = eval(f"({left_scale}*{val1}) {op} ({right_scale} * {val2})")
+        decision_boolean = eval(f"(left_scale*val1) {op} (right_scale * val2)")
 
         comptable = change_comptable_classifications(
             comptable, ifTrue, ifFalse, decision_boolean, str(decision_node_idx)


### PR DESCRIPTION
Work-in-progress improvements for the decision tree modularization. Key changes here are:
- In the JSON specification for the decision tree added  `intermediate_classifications` and `classification_tags` and made sure both of these are validated correctly when the tree is loaded. Note the intermediate classifications can be used without program, but the classification tags are not actually used yet.
- Removed `ignored` as a default classification and replace it with `lowvariance` in the minimal tree
- Replaced `metric1_greaterthan_metric2` with `left_op_right` which allows for any boolean relationship operator. Minimal decision tree now successfully uses this function.
- Replaced the use of `create_dnode_outputs` in all nodes involved with the minimal decision tree with the original definition of an `output` dictionary and adjusted called to variables that are saved in outputs accordingly.

NOTE: with the above changes, particularly the removal of `metric1_greaterthan_metric2` the kundu decision tree is now broken. Once everything is cleaned up for the minimal decision tree, the corrections will be made for functions only used in the kundu decision tree. 