### PR TITLE
Decision tree improvements

### DIFF
--- a/docs/building_decision_trees.rst
+++ b/docs/building_decision_trees.rst
@@ -1,0 +1,249 @@
+########################################################
+Understanding and building a component selection process
+########################################################
+
+``tedana`` involve transforming data into components via ICA, and then calculating metrics for each component.
+Each metric has one value per component that is stored in a comptable or component_table dataframe. This structure
+is then pass to a "decision tree" which through a series of binary choices categories each component as accepted or
+rejected. The time series for the rejected components are regressed from the data in the final denoising step.
+
+There are several decision trees that are included by default in ``tedana`` but users can also build their own.
+This might be useful both if one of the default decision trees needs to be slightly altered due to the nature
+of a specific data set, if one has an idea for a new approach to multi-echo denoising, or if one wants to integrate
+non-multi-echo metrics into a single decision tree.
+
+Note: We use two terminologies interchangably. This whole process is called "component selection"
+and much of the code uses variants of that phrase (i.e. the ComponentSelector class, selection_nodes for the functions used in selection).
+Instructions for how to classify components is called a "decision tree" since each step in the selection
+process branches components into different intermediate or final classifications
+
+.. contents:: :local:
+
+
+******************************************
+Expected outputs after component selection
+******************************************
+
+*New rows in the component_table or comptable*
+
+The default file name for the component table is: ``desc-tedana_metrics.tsv``
+
+classification:
+    In the final table, the only values should be 'accepted' or 'rejected'.
+    While the decision table is bring running, there may also be intermediate
+    classification labels. Note, nothing in the current code requires a tree to
+    assign one of these two labels to every component. There will be a warning
+    if other labels remain
+
+classification_tags:
+    Human readable tags that explain why a classification was reached. These can
+    be things like 'Likely BOLD', 'Unlikely BOLD', 'low variance' (i.e. accepted
+    because the variance is too low to low a degree of freedom by calling it noise).
+    Each component can have no tags (an empty string), one tag, or a comma separated
+    list of tags.
+
+**Data stored in the ComponentSelector class variable selector**
+
+(Where these are stored is currently a work in progress, but they're currently in selector)
+
+cross_component_metrics:
+    Metrics that are each a single value calculated across components. For example, kappa and rho elbows.
+
+component_status_table:
+    A table where each column lists the classification status of
+    each component after each node was run. This is useful for understanding the classification
+    path of each component through the decision tree
+
+used_metrics:
+    A list of the metrics that were used in the decision tree.
+
+classification_tags:
+    A list of the pre-specified classification tags that could be used in a decision tree.
+    Any reporting interface should use this field so that the tags that are possible are listed
+    even if no components are assigned a specific tag.
+    
+**Outputs of each decision tree step**
+
+This includes all the information from the inputted decision tree under each "node" or function
+call. For each node, there is also an "outputs" subfield with information from when the tree
+was executed
+(Currently also in selector, but should be saved as a json file)
+
+decison_node_idx:
+    The decision tree functions are run as part of an ordered list.
+    This is the positional index for when this function was run
+    as part of this list. (First index is 0)
+    
+used_metrics:
+    A list of the metrics used in a node of the decision tree
+
+used_cross_component_metrics:
+    A list of cross component metrics used in the node of a decision tree
+
+node_label:
+    A brief label for what happens in this node that can be used in a decision
+    tree summary table or flow chart.
+
+numTrue, numFalse:
+    For decision tree (dec) functions, the number of components that were classified
+    as true or false respectively in this decision tree step.
+
+calc_cross_comp_metrics:
+    For calculation (calc) functions, cross component metrics that were
+    calculated in this function. When this is included, each of those
+    metrics and the calculated values are also distinct keys in 'outputs'.
+    While the cross component metrics table does not include where each component
+    was calculated, that information is stored here.
+
+
+******************************************
+Understanding the parts of a decision tree
+******************************************
+
+Decision trees are stored in json files. The default trees are with the tedana code in ./resources/decision_trees
+The minimal tree, minimal.json is a good example highlighting the structure and steps in a tree. It may be helpful
+to look at that tree while reading this section.
+
+A user can specify another decision tree and link to the tree location when tedana is executed. The format is
+flexible to allow for future innovations, but that also means, it's flexible enough for someone who designs a tree
+to create something with non-ideal results for the current code. Some criteria will result in an error
+if violated, but more will just give a warning. If you are designing or editing a tree, look carefully at the warnings.
+
+A decision tree can include two types of nodes or functions. All functions are currently in selection_nodes.py
+- A decision function will use existing metrics and potentially change the classification of the components based on those metrics. By convention, all these functions should begin with "dec"
+- A calculation function will take existing metrics and calculate a value across components to be used for classification, for example the kappa and rho elbows. By convention, all these functions should begin with "calc"
+Nothing prevents a function from both calculating new cross component values and applying those values in a decision step, but following this convention should hopefully make decision tree specifications easier to follow and interpret.
+
+**Key expectations**
+
+- All trees should start with a "manual_classification" node that should set all component classifications to "unclassified" and
+  have "clear_classification_tags" set to true. There might be special cases where someone might want to violate these rules
+  but, depending what else happens in preceding code, other functions will expect both of these columns to exist.
+  This manual_classification step will make sure those columns are created and initialized.
+- Every possible path through the tree should result in each component being classified as 'accepted' or 'rejected'
+- Three initialization variables will help prevent mistakes
+  
+  necessary_metrics:
+      Is a list of the necessary metrics in the component table that will be used by the tree. If a metric doesn't exist then this
+      will raise an error instead of executing a tree. (This can eventually be used to call the metric calculation code based on
+      the decision tree specification). If a necessary metric isn't used, there will be a warning. This is just a warning because,
+      if the decision tree code specification is eventually used to calculated metrics, one may want to calculate a metric even if
+      it's not being used.
+
+  intermediate_classifications:
+      A list of intermediate classifications (i.e. "provisionalaccept", "provisionalreject"). It is very important to prespecify these
+      because the code will make sure only the default classifications ("accepted" "rejected" "unclassified") and intermediate classifications
+      are used in a tree. This prevents someone from accidentially losing a component due to a spelling error or other minor variation in a
+      classification label
+
+  classification_tags:
+      A list of acceptable classification tags (i.e. "Likely BOLD", "Unlikely BOLD", "Low variance"). This will both be used to make sure only
+      these tags are used in the tree and allow programs that interact with the results one place to see all potential tags
+
+**Decision node json structure**
+
+There are  6 initial fields, necessary_metrics, intermediate_classification, and classification_tags, as described in the above section:
+
+- "tree_id": a descriptive name for the tree that will be logged.
+- "info": A brief description of the tree for info logging
+- "report": A narrative description of the tree that could be used in report logging
+- "refs" Publications that should be referenced, when this tree is used
+
+The "nodes" field is a list of elements where each element defines a node the decision tree. There are several key fields for each of these nodes:
+
+- "functionname": The exact function name in selection_nodes.py that will be called.
+- "parameters": Specifications of all required parameters for the function in functionname
+- "kwargs": Specification for optional parameters for the function in functionname
+
+The only parameter that is used in all functions is "decidecomps" which is used to identify, based on their classifications,
+the components a function should be applied to. It can be a single classification, or a comma separated string of classificaions.
+In addition to the intermediate and default ("accepted" "rejected" "unclassified") component classifications, this can be "all"
+for functions that should be applied to all components regardless of their classifications
+
+Most decision functions also include "ifTrue" and "ifFalse" which specify how to change the classification of each component
+based on whether a the decision criterion is true or also. In addition to the default and intermediate classification options,
+this can also be "nochange" (i.e. For components where a>b is true, "reject". For components where a>b is false, "nochange").
+The optional parameters "tag_ifTrue" and "tag_ifFalse" define the classification tags to be assigned to components.
+Currently, the only exception is "manual_classify" which uses "new_classification" to designate the new component classification
+and "tag" (optional) to designate which classification tag to apply.
+
+There are several optional parameters in every decision tree function:
+
+- custom_node_label: A brief label for what happens in this node that can be used in a decision tree summary table or flow chart. If custom_node_label is not not defined, then each function has default descriptive text.
+- log_extra_report, log_extra_info: Text for each function call is automatically placed in the logger output. In addition to that text, the text in these these strings will also be included in the logger with the report or info codes respectively. These might be useful to give a narrative explanation of why a step was parameterized a certain way.
+- only_used_metrics: If true, this function will only return the names of the component table metrics that will be used when this function is fully run. This can be used to identify all used metrics before running the decision tree.
+
+********************************
+Key parts of selection functions
+********************************
+
+There are several expectations for selection functions that are necessary for them to properly execute.
+In selection_nodes.py, manual_classify, dec_left_op_right, and calc_kappa_rho_elbows_kundu are good
+examples for how to meet these expectations.
+
+Create a dictionary called "outputs" that includes key fields that should be recorded. 
+The following line should be at the end of each function ``selector.nodes[selector.current_node_idx]["outputs"] = outputs`` 
+Additional fields can be used to log funciton-specific information, but the following fields are common and may be used by other parts of the code:
+
+- "decision_node_idx" (required): the ordered index for the current function in the decision tree.
+- "node_label" (required): A decriptive label for what happens in the node.
+- "numTrue" & "numFalse" (required for decision functions): For decision functions, the number of components labels true or false within the function call.
+- "used_metrics" (required if a function uses metrics): The list of metrics used in the function. This can be hard coded, defined by input parameters, or empty.
+- "used_cross_component_metrics" (required if a function uses cross component metrics): A list of cross component metrics used in the function. This can be hard coded, defined by input parameters, or empty.
+- "calc_cross_comp_metrics" (required for calculation functions): A list of cross component metrics calculated within the function. The key-value pair for each calculated metric is also included in "outputs"
+
+Before anything data are touched in the function, there should be an ``if only_used_metrics:`` clause that returns ``used_metrics`` for the function call
+
+Existing functions define ``function_name_idx = f"Step {selector.current_node_idx}: [text of function_name]`` This is used several times in logging and is nice to define only once.
+
+
+Code the executes ``outputs["node_label"] = custom_node_label`` if there is a user-inputted custom node label or assigned a default node label. The default node lable
+may be used in decision tree visualization so it should be relatively short.
+
+Calculation nodes should check if the value they are calculating was already calculated and output a warning if the function overwrites and existing value
+
+Code that adds the text log_extra_info and log_extra_report into the appropriate logs (if they are provided by the user)
+
+After the above information is included, all functions will call ``selectcomps2use`` which returns the components with classifications included in ``decide_comps``
+Then run ``confirm_metrics_exist`` which is an added check to make sure the metrics used by this function exist in the component table.
+
+Nearly every function has a clause like:
+
+.. code-block:: python
+
+  if comps2use is None:
+     log_decision_tree_step(function_name_idx, comps2use, decide_comps=decide_comps)
+     outputs["numTrue"] = 0
+     outputs["numFalse"] = 0
+  else:
+
+If there are no components with the classifications in ``decide_comps`` this logs that there's nothing for the function to be run on, else continue.
+
+For decision functions the key variable is ``decision_boolean`` which should be a dataframe column which is True or False based on the function's criteria.
+That column is an input to ``change_comptable_classifications`` which will update the component_table classifications, update the classification history in component_status_table,
+and update the component classification_tags.
+
+This is followed by something that logs how many components were identified as true or false, like:
+
+.. code-block:: python
+
+  outputs["numTrue"] = np.asarray(decision_boolean).sum()
+  outputs["numFalse"] = np.logical_not(decision_boolean).sum()
+
+For calculation functions, the calculated values should be added as a value/key pair to both ``selector.cross_component_metrics`` and ``outputs``
+
+``log_decision_tree_step`` puts the relevant info from the function call into the program's output log.
+
+Every function should end.
+
+.. code-block:: python
+
+      selector.nodes[selector.current_node_idx]["outputs"] = outputs
+      return selector
+
+  functionname.__doc__ = (functionname.__doc__.format(**decision_docs))
+
+This returns makes sure the outputs from the function are saved in the class structure and the class structure is return.
+The following line should include the function's name and is used to make sure repeated variable names are compiled correctly for the API documentation.
+
+If you follow these simple steps you'll be able design your very own decision tree functions.

--- a/docs/building_decision_trees.rst
+++ b/docs/building_decision_trees.rst
@@ -42,9 +42,7 @@ classification_tags:
     Each component can have no tags (an empty string), one tag, or a comma separated
     list of tags.
 
-**Data stored in the ComponentSelector class variable selector**
-
-(Where these are stored is currently a work in progress, but they're currently in selector)
+**Data stored in the ComponentSelector object**
 
 cross_component_metrics:
     Metrics that are each a single value calculated across components. For example, kappa and rho elbows.
@@ -96,9 +94,9 @@ calc_cross_comp_metrics:
     was calculated, that information is stored here.
 
 
-******************************************
-Understanding the parts of a decision tree
-******************************************
+*********************************
+Defining a custom a decision tree
+*********************************
 
 Decision trees are stored in json files. The default trees are with the tedana code in ./resources/decision_trees
 The minimal tree, minimal.json is a good example highlighting the structure and steps in a tree. It may be helpful
@@ -110,6 +108,7 @@ to create something with non-ideal results for the current code. Some criteria w
 if violated, but more will just give a warning. If you are designing or editing a tree, look carefully at the warnings.
 
 A decision tree can include two types of nodes or functions. All functions are currently in selection_nodes.py
+
 - A decision function will use existing metrics and potentially change the classification of the components based on those metrics. By convention, all these functions should begin with "dec"
 - A calculation function will take existing metrics and calculate a value across components to be used for classification, for example the kappa and rho elbows. By convention, all these functions should begin with "calc"
 Nothing prevents a function from both calculating new cross component values and applying those values in a decision step, but following this convention should hopefully make decision tree specifications easier to follow and interpret.

--- a/docs/building_decision_trees.rst
+++ b/docs/building_decision_trees.rst
@@ -4,8 +4,8 @@ Understanding and building a component selection process
 
 ``tedana`` involves transforming data into components via ICA, and then calculating metrics for each component.
 Each metric has one value per component that is stored in a comptable or component_table dataframe. This structure
-is then passed to a "decision tree" which through a series of binary choices categories each component as accepted or
-rejected. The time series for the rejected components are regressed from the data in the final denoising step.
+is then passed to a "decision tree" which through a series of binary choices categories each component as **accepted** or
+**rejected**. The time series for the rejected components are regressed from the data in the final denoising step.
 
 There are several decision trees that are included by default in ``tedana`` but users can also build their own.
 This might be useful if one of the default decision trees needs to be slightly altered due to the nature
@@ -102,7 +102,7 @@ Decision trees are stored in json files. The default trees are stored as part of
 The minimal tree, minimal.json is a good example highlighting the structure and steps in a tree. It may be helpful
 to look at that tree while reading this section.
 
-A user can specify another decision tree and link to the tree location when tedana is executed. The format is
+A user can specify another decision tree and link to the tree location when tedana is executed with the ``--tree`` option. The format is
 flexible to allow for future innovations, but be advised that this also allows you to
 to create something with non-ideal results for the current code. Some criteria will result in an error
 if violated, but more will just give a warning. If you are designing or editing a tree, look carefully at the warnings.
@@ -193,11 +193,12 @@ Additional fields can be used to log funciton-specific information, but the foll
 
 Before anything data are touched in the function, there should be an ``if only_used_metrics:`` clause that returns ``used_metrics`` for the function call
 
-Existing functions define ``function_name_idx = f"Step {selector.current_node_idx}: [text of function_name]`` This is used several times in logging and is nice to define only once.
+Existing functions define ``function_name_idx = f"Step {selector.current_node_idx}: [text of function_name]`` This is used in logging and is cleaner to initialize near the top of each function.
 
 
-Code the executes ``outputs["node_label"] = custom_node_label`` if there is a user-inputted custom node label or assigned a default node label. The default node lable
-may be used in decision tree visualization so it should be relatively short.
+Each function has code that creates a default node label in ``outputs["node_label"]``. The default node lable
+may be used in decision tree visualization so it should be relatively short. Within this section, if there is
+a user-provided custom_node_label, that should be used instead.
 
 Calculation nodes should check if the value they are calculating was already calculated and output a warning if the function overwrites and existing value
 
@@ -218,16 +219,12 @@ Nearly every function has a clause like:
 
 If there are no components with the classifications in ``decide_comps`` this logs that there's nothing for the function to be run on, else continue.
 
-For decision functions the key variable is ``decision_boolean`` which should be a dataframe column which is True or False based on the function's criteria.
-That column is an input to ``change_comptable_classifications`` which will update the component_table classifications, update the classification history in component_status_table,
-and update the component classification_tags.
-
-This is followed by something that logs how many components were identified as true or false, like:
-
-.. code-block:: python
-
-  outputs["numTrue"] = np.asarray(decision_boolean).sum()
-  outputs["numFalse"] = np.logical_not(decision_boolean).sum()
+For decision functions the key variable is ``decision_boolean`` which should be a dataframe column which is True or False for the components in ``decide_comps``
+based on the function's criteria. That column is an input to ``change_comptable_classifications`` which will update the component_table classifications,
+update the classification history in component_status_table, and update the component classification_tags. Components not in ``decide_comps`` retain their
+existing classifications and tags.
+``change_comptable_classifications`` also outputs and should assign values to ``outputs["numTrue"]`` and ``outputs["numFalse"]``.
+These log how many components were identified as true or false within each function.
 
 For calculation functions, the calculated values should be added as a value/key pair to both ``selector.cross_component_metrics`` and ``outputs``
 
@@ -245,4 +242,5 @@ Every function should end.
 This returns makes sure the outputs from the function are saved in the class structure and the class structure is returned.
 The following line should include the function's name and is used to make sure repeated variable names are compiled correctly for the API documentation.
 
-If you follow these simple steps you'll be able design your very own decision tree functions.
+If you have made it this far, congratulations. 
+If you follow these steps you'll be to impress your colleagues, friends, and family by designing your very own decision tree functions.

--- a/tedana/metrics/collect.py
+++ b/tedana/metrics/collect.py
@@ -538,15 +538,7 @@ def get_metadata(comptable):
                 ),
             },
         }
-    # if "original_rationale" in comptable:
-    #     metric_metadata["original_rationale"] = {
-    #         "LongName": "Original rationale",
-    #         "Description": (
-    #             "The reason for the original classification. "
-    #             "Please see tedana's documentation for information about "
-    #             "possible rationales."
-    #         ),
-    #     }
+
     if "classification" in comptable:
         metric_metadata["classification"] = {
             "LongName": "Component classification",
@@ -559,19 +551,21 @@ def get_metadata(comptable):
                     "A non-BOLD component excluded from denoised and "
                     "high-Kappa data."
                 ),
-                "ignored": (
-                    "A low-variance component included in denoised, "
-                    "but excluded from high-Kappa data."
-                ),
             },
+        }
+    if "classification_tags" in comptable:
+        metric_metadata["classification_tags"] = {
+            "LongName": "Component classification tags",
+            "Description": (
+                "A single tag or a comma separated list of tags to describe why a component received its classification"
+            ),
         }
     if "rationale" in comptable:
         metric_metadata["rationale"] = {
             "LongName": "Rationale for component classification",
             "Description": (
                 "The reason for the original classification. "
-                "Please see tedana's documentation for information about "
-                "possible rationales."
+                "This column label was replaced with classification_tags in late 2021"
             ),
         }
     if "kappa ratio" in comptable:

--- a/tedana/metrics/collect.py
+++ b/tedana/metrics/collect.py
@@ -116,9 +116,7 @@ def generate_metrics(
     n_components = mixing.shape[1]
     comptable = pd.DataFrame(index=np.arange(n_components, dtype=int))
     comptable["Component"] = [
-        io.add_decomp_prefix(
-            comp, prefix=label, max_value=comptable.shape[0]
-        )
+        io.add_decomp_prefix(comp, prefix=label, max_value=comptable.shape[0])
         for comp in comptable.index.values
     ]
 
@@ -140,9 +138,7 @@ def generate_metrics(
             data_optcom, mixing
         )
         if io_generator.verbose:
-            metric_maps["map echo betas"] = dependence.calculate_betas(
-                data_cat, mixing
-            )
+            metric_maps["map echo betas"] = dependence.calculate_betas(data_cat, mixing)
 
     if "map percent signal change" in required_metrics:
         LGR.info("Calculating percent signal change maps")
@@ -158,7 +154,7 @@ def generate_metrics(
         if io_generator.verbose:
             io_generator.save_file(
                 utils.unmask(metric_maps["map Z"] ** 2, mask),
-                label + ' component weights img',
+                label + " component weights img",
             )
 
     if ("map FT2" in required_metrics) or ("map FS0" in required_metrics):
@@ -341,37 +337,47 @@ def generate_metrics(
                 echo_betas = betas[:, i_echo, :]
                 io_generator.save_file(
                     utils.unmask(echo_betas, mask),
-                    'echo weight ' + label + ' map split img',
-                    echo=(i_echo + 1)
+                    "echo weight " + label + " map split img",
+                    echo=(i_echo + 1),
                 )
 
             if write_T2S0:
                 echo_pred_T2_maps = pred_T2_maps[:, i_echo, :]
                 io_generator.save_file(
                     utils.unmask(echo_pred_T2_maps, mask),
-                    'echo T2 ' + label + ' split img',
-                    echo=(i_echo + 1)
+                    "echo T2 " + label + " split img",
+                    echo=(i_echo + 1),
                 )
 
                 echo_pred_S0_maps = pred_S0_maps[:, i_echo, :]
                 io_generator.save_file(
                     utils.unmask(echo_pred_S0_maps, mask),
-                    'echo S0 ' + label + ' split img',
-                    echo=(i_echo + 1)
+                    "echo S0 " + label + " split img",
+                    echo=(i_echo + 1),
                 )
 
     # Reorder component table columns based on previous tedana versions
     # NOTE: Some new columns will be calculated and columns may be reordered during
     # component selection
     preferred_order = (
-        "Component", "kappa", "rho", "variance explained",
+        "Component",
+        "kappa",
+        "rho",
+        "variance explained",
         "normalized variance explained",
         "estimated normalized variance explained",
-        "countsigFT2", "countsigFS0",
-        "dice_FT2", "dice_FS0",
-        "countnoise", "signal-noise_t", "signal-noise_p",
-        "d_table_score", "kappa ratio", "d_table_score_scrub",
-        "classification", "rationale",
+        "countsigFT2",
+        "countsigFS0",
+        "dice_FT2",
+        "dice_FS0",
+        "countnoise",
+        "signal-noise_t",
+        "signal-noise_p",
+        "d_table_score",
+        "kappa ratio",
+        "d_table_score_scrub",
+        "classification",
+        "rationale",
     )
     first_columns = [col for col in preferred_order if col in comptable.columns]
     other_columns = [col for col in comptable.columns if col not in preferred_order]
@@ -468,9 +474,7 @@ def get_metadata(comptable):
         }
     if "dice_FS0" in comptable:
         metric_metadata["dice_FS0"] = {
-            "LongName": (
-                "S0 model beta map-F-statistic map Dice similarity index"
-            ),
+            "LongName": ("S0 model beta map-F-statistic map Dice similarity index"),
             "Description": (
                 "Dice value of cluster-extent thresholded maps of "
                 "S0-model betas and F-statistics."
@@ -519,13 +523,10 @@ def get_metadata(comptable):
     if "original_classification" in comptable:
         metric_metadata["original_classification"] = {
             "LongName": "Original classification",
-            "Description": (
-                "Classification from the original decision tree."
-            ),
+            "Description": ("Classification from the original decision tree."),
             "Levels": {
                 "accepted": (
-                    "A BOLD-like component included in denoised and "
-                    "high-Kappa data."
+                    "A BOLD-like component included in denoised and " "high-Kappa data."
                 ),
                 "rejected": (
                     "A non-BOLD component excluded from denoised and "
@@ -537,25 +538,22 @@ def get_metadata(comptable):
                 ),
             },
         }
-    if "original_rationale" in comptable:
-        metric_metadata["original_rationale"] = {
-            "LongName": "Original rationale",
-            "Description": (
-                "The reason for the original classification. "
-                "Please see tedana's documentation for information about "
-                "possible rationales."
-            ),
-        }
+    # if "original_rationale" in comptable:
+    #     metric_metadata["original_rationale"] = {
+    #         "LongName": "Original rationale",
+    #         "Description": (
+    #             "The reason for the original classification. "
+    #             "Please see tedana's documentation for information about "
+    #             "possible rationales."
+    #         ),
+    #     }
     if "classification" in comptable:
         metric_metadata["classification"] = {
             "LongName": "Component classification",
-            "Description": (
-                "Classification from the manual classification procedure."
-            ),
+            "Description": ("Classification from the manual classification procedure."),
             "Levels": {
                 "accepted": (
-                    "A BOLD-like component included in denoised and "
-                    "high-Kappa data."
+                    "A BOLD-like component included in denoised and " "high-Kappa data."
                 ),
                 "rejected": (
                     "A non-BOLD component excluded from denoised and "

--- a/tedana/reporting/static_figures.py
+++ b/tedana/reporting/static_figures.py
@@ -6,17 +6,18 @@ import os
 
 import numpy as np
 import matplotlib
-matplotlib.use('AGG')
+
+matplotlib.use("AGG")
 import matplotlib.pyplot as plt
 from nilearn import plotting
 
 from tedana import io, stats, utils
 
 LGR = logging.getLogger("GENERAL")
-MPL_LGR = logging.getLogger('matplotlib')
+MPL_LGR = logging.getLogger("matplotlib")
 MPL_LGR.setLevel(logging.WARNING)
-RepLGR = logging.getLogger('REPORT')
-RefLGR = logging.getLogger('REFERENCES')
+RepLGR = logging.getLogger("REPORT")
+RefLGR = logging.getLogger("REFERENCES")
 
 
 def _trim_edge_zeros(arr):
@@ -38,12 +39,14 @@ def _trim_edge_zeros(arr):
 
     mask = arr != 0
     bounding_box = tuple(
-                         slice(np.min(indexes), np.max(indexes) + 1)
-                         for indexes in np.where(mask))
+        slice(np.min(indexes), np.max(indexes) + 1) for indexes in np.where(mask)
+    )
     return arr[bounding_box]
 
 
-def carpet_plot(optcom_ts, denoised_ts, hikts, lowkts, mask, io_generator, gscontrol=None):
+def carpet_plot(
+    optcom_ts, denoised_ts, hikts, lowkts, mask, io_generator, gscontrol=None
+):
     """Generate a set of carpet plots for the combined and denoised data.
 
     Parameters
@@ -122,7 +125,9 @@ def carpet_plot(optcom_ts, denoised_ts, hikts, lowkts, mask, io_generator, gscon
             title="Optimally Combined Data (Pre-GSR)",
         )
         fig.tight_layout()
-        fig.savefig(os.path.join(io_generator.out_dir, "figures", "carpet_optcom_nogsr.svg"))
+        fig.savefig(
+            os.path.join(io_generator.out_dir, "figures", "carpet_optcom_nogsr.svg")
+        )
 
     if (gscontrol is not None) and ("mir" in gscontrol):
         mir_denoised_img = io_generator.get_name("mir denoised img")
@@ -135,7 +140,9 @@ def carpet_plot(optcom_ts, denoised_ts, hikts, lowkts, mask, io_generator, gscon
             title="Denoised Data (Post-MIR)",
         )
         fig.tight_layout()
-        fig.savefig(os.path.join(io_generator.out_dir, "figures", "carpet_denoised_mir.svg"))
+        fig.savefig(
+            os.path.join(io_generator.out_dir, "figures", "carpet_denoised_mir.svg")
+        )
 
         mir_denoised_img = io_generator.get_name("ICA accepted mir denoised img")
         fig, ax = plt.subplots(figsize=(14, 7))
@@ -147,7 +154,9 @@ def carpet_plot(optcom_ts, denoised_ts, hikts, lowkts, mask, io_generator, gscon
             title="High-Kappa Data (Post-MIR)",
         )
         fig.tight_layout()
-        fig.savefig(os.path.join(io_generator.out_dir, "figures", "carpet_accepted_mir.svg"))
+        fig.savefig(
+            os.path.join(io_generator.out_dir, "figures", "carpet_accepted_mir.svg")
+        )
 
 
 def comp_figures(ts, mask, comptable, mmix, io_generator, png_cmap):
@@ -191,32 +200,36 @@ def comp_figures(ts, mask, comptable, mmix, io_generator, png_cmap):
 
     # Create indices for 6 cuts, based on dimensions
     cuts = [ts_B.shape[dim] // 6 for dim in range(3)]
-    expl_text = ''
+    expl_text = ""
 
     # Remove trailing ';' from rationale column
-    comptable['rationale'] = comptable['rationale'].str.rstrip(';')
+    # comptable['rationale'] = comptable['rationale'].str.rstrip(';')
     for compnum in comptable.index.values:
-        if comptable.loc[compnum, "classification"] == 'accepted':
-            line_color = 'g'
-            expl_text = 'accepted'
-        elif comptable.loc[compnum, "classification"] == 'rejected':
-            line_color = 'r'
-            expl_text = 'rejection reason(s): ' + comptable.loc[compnum, "rationale"]
-        elif comptable.loc[compnum, "classification"] == 'ignored':
-            line_color = 'k'
-            expl_text = 'ignored reason(s): ' + comptable.loc[compnum, "rationale"]
+        if comptable.loc[compnum, "classification"] == "accepted":
+            line_color = "g"
+            expl_text = (
+                "accepted reason(s): " + comptable.loc[compnum, "classification_tags"]
+            )
+        elif comptable.loc[compnum, "classification"] == "rejected":
+            line_color = "r"
+            expl_text = (
+                "rejection reason(s): " + comptable.loc[compnum, "classification_tags"]
+            )
+        elif comptable.loc[compnum, "classification"] == "ignored":
+            line_color = "k"
+            expl_text = (
+                "ignored reason(s): " + comptable.loc[compnum, "classification_tags"]
+            )
         else:
             # Classification not added
             # If new, this will keep code running
-            line_color = '0.75'
-            expl_text = 'other classification'
+            line_color = "0.75"
+            expl_text = "other classification"
 
         allplot = plt.figure(figsize=(10, 9))
-        ax_ts = plt.subplot2grid((5, 6), (0, 0),
-                                 rowspan=1, colspan=6,
-                                 fig=allplot)
+        ax_ts = plt.subplot2grid((5, 6), (0, 0), rowspan=1, colspan=6, fig=allplot)
 
-        ax_ts.set_xlabel('TRs')
+        ax_ts.set_xlabel("TRs")
         ax_ts.set_xlim(0, n_vols)
         plt.yticks([])
         # Make a second axis with units of time (s)
@@ -235,7 +248,7 @@ def comp_figures(ts, mask, comptable, mmix, io_generator, png_cmap):
         ax_ts2.set_xticks(ax1Xs)
         ax_ts2.set_xlim(ax_ts.get_xbound())
         ax_ts2.set_xticklabels(ax2Xs)
-        ax_ts2.set_xlabel('seconds')
+        ax_ts2.set_xlabel("seconds")
 
         ax_ts.plot(mmix[:, compnum], color=line_color)
 
@@ -243,9 +256,9 @@ def comp_figures(ts, mask, comptable, mmix, io_generator, png_cmap):
         comp_var = "{0:.2f}".format(comptable.loc[compnum, "variance explained"])
         comp_kappa = "{0:.2f}".format(comptable.loc[compnum, "kappa"])
         comp_rho = "{0:.2f}".format(comptable.loc[compnum, "rho"])
-        plt_title = ('Comp. {}: variance: {}%, kappa: {}, rho: {}, '
-                     '{}'.format(compnum, comp_var, comp_kappa, comp_rho,
-                                 expl_text))
+        plt_title = "Comp. {}: variance: {}%, kappa: {}, rho: {}, " "{}".format(
+            compnum, comp_var, comp_kappa, comp_rho, expl_text
+        )
         title = ax_ts.set_title(plt_title)
         title.set_y(1.5)
 
@@ -255,8 +268,10 @@ def comp_figures(ts, mask, comptable, mmix, io_generator, png_cmap):
 
         for idx, _ in enumerate(cuts):
             for imgslice in range(1, 6):
-                ax = plt.subplot2grid((5, 6), (idx + 1, imgslice - 1), rowspan=1, colspan=1)
-                ax.axis('off')
+                ax = plt.subplot2grid(
+                    (5, 6), (idx + 1, imgslice - 1), rowspan=1, colspan=1
+                )
+                ax.axis("off")
 
                 if idx == 0:
                     to_plot = np.rot90(ts_B[imgslice * cuts[idx], :, :, compnum])
@@ -265,14 +280,15 @@ def comp_figures(ts, mask, comptable, mmix, io_generator, png_cmap):
                 if idx == 2:
                     to_plot = ts_B[:, :, imgslice * cuts[idx], compnum]
 
-                ax_im = ax.imshow(to_plot, vmin=imgmin, vmax=imgmax, aspect='equal',
-                                  cmap=png_cmap)
+                ax_im = ax.imshow(
+                    to_plot, vmin=imgmin, vmax=imgmax, aspect="equal", cmap=png_cmap
+                )
 
         # Add a color bar to the plot.
         ax_cbar = allplot.add_axes([0.8, 0.3, 0.03, 0.37])
         cbar = allplot.colorbar(ax_im, ax_cbar)
-        cbar.set_label('Component Beta', rotation=90)
-        cbar.ax.yaxis.set_label_position('left')
+        cbar.set_label("Component Beta", rotation=90)
+        cbar.ax.yaxis.set_label_position("left")
 
         # Get fft and freqs for this subject
         # adapted from @dangom
@@ -281,14 +297,14 @@ def comp_figures(ts, mask, comptable, mmix, io_generator, png_cmap):
         # Plot it
         ax_fft = plt.subplot2grid((5, 6), (4, 0), rowspan=1, colspan=6)
         ax_fft.plot(freqs, spectrum)
-        ax_fft.set_title('One Sided fft')
-        ax_fft.set_xlabel('Hz')
+        ax_fft.set_title("One Sided fft")
+        ax_fft.set_xlabel("Hz")
         ax_fft.set_xlim(freqs[0], freqs[-1])
         plt.yticks([])
 
         # Fix spacing so TR label does overlap with other plots
         allplot.subplots_adjust(hspace=0.4)
-        plot_name = 'comp_{}.png'.format(str(compnum).zfill(3))
-        compplot_name = os.path.join(io_generator.out_dir, 'figures', plot_name)
+        plot_name = "comp_{}.png".format(str(compnum).zfill(3))
+        compplot_name = os.path.join(io_generator.out_dir, "figures", plot_name)
         plt.savefig(compplot_name)
         plt.close()

--- a/tedana/resources/decision_trees/minimal.json
+++ b/tedana/resources/decision_trees/minimal.json
@@ -102,8 +102,7 @@
         {
             "functionname": "calc_kappa_rho_elbows_kundu",
             "parameters": {
-                "decide_comps": "unclassified",
-                "n_echos": null
+                "decide_comps": "unclassified"
             },
             "kwargs": {
                 "log_extra_info": "",

--- a/tedana/resources/decision_trees/minimal.json
+++ b/tedana/resources/decision_trees/minimal.json
@@ -32,7 +32,8 @@
             "kwargs": {
                 "log_extra_info": "Initializing all classifications as unclassified and all classification tags as blank",
                 "log_extra_report": "",
-                "clear_classification_tags": true
+                "clear_classification_tags": true,
+                "dont_warn_reclassify": true
             }
         },
         {

--- a/tedana/resources/decision_trees/minimal.json
+++ b/tedana/resources/decision_trees/minimal.json
@@ -36,7 +36,7 @@
             }
         },
         {
-            "functionname": "left_op_right",
+            "functionname": "dec_left_op_right",
             "parameters": {
                 "ifTrue": "rejected",
                 "ifFalse": "nochange",
@@ -51,7 +51,7 @@
             }
         },
         {
-            "functionname": "left_op_right",
+            "functionname": "dec_left_op_right",
             "parameters": {
                 "ifTrue": "rejected",
                 "ifFalse": "nochange",
@@ -66,7 +66,7 @@
             }
         },
         {
-            "functionname": "left_op_right",
+            "functionname": "dec_left_op_right",
             "parameters": {
                 "ifTrue": "rejected",
                 "ifFalse": "nochange",
@@ -81,7 +81,7 @@
             }
         },
         {
-            "functionname": "left_op_right",
+            "functionname": "dec_left_op_right",
             "parameters": {
                 "ifTrue": "rejected",
                 "ifFalse": "nochange",
@@ -96,21 +96,33 @@
             }
         },
         {
-            "functionname": "kappa_rho_elbow_cutoffs_kundu",
+            "functionname": "calc_kappa_rho_elbows_kundu",
             "parameters": {
-                "ifTrue": "provisionalaccept",
-                "ifFalse": "nochange",
                 "decide_comps": "unclassified",
                 "n_echos": null
             },
             "kwargs": {
-                "kappa_only": true,
                 "log_extra_info": "",
                 "log_extra_report": ""
             }
         },
         {
-            "functionname": "left_op_right",
+            "functionname": "dec_left_op_right",
+            "parameters": {
+                "ifTrue": "provisionalaccept",
+                "ifFalse": "nochange",
+                "decide_comps": "unclassified",
+                "op": ">",
+                "left": "kappa",
+                "right": "kappa_elbow_kundu"
+            },
+            "kwargs": {
+                "log_extra_info": "kappa>elbow",
+                "log_extra_report": ""
+            }
+        },
+        {
+            "functionname": "dec_left_op_right",
             "parameters": {
                 "ifTrue": "accepted",
                 "ifFalse": "nochange",
@@ -126,7 +138,7 @@
             }
         },
         {
-            "functionname": "kappa_rho_elbow_cutoffs_kundu",
+            "functionname": "dec_left_op_right",
             "parameters": {
                 "ifTrue": "nochange",
                 "ifFalse": "provisionalreject",
@@ -134,16 +146,17 @@
                     "unclassified",
                     "provisionalaccept"
                 ],
-                "n_echos": null
+                "op": ">",
+                "left": "rho",
+                "right": "rho_elbow_kundu"
             },
             "kwargs": {
-                "rho_only": true,
-                "log_extra_info": "",
+                "log_extra_info": "rho>elbow",
                 "log_extra_report": ""
             }
         },
         {
-            "functionname": "variance_lessthan_thresholds",
+            "functionname": "dec_variance_lessthan_thresholds",
             "parameters": {
                 "ifTrue": "lowvariance",
                 "ifFalse": "nochange",

--- a/tedana/resources/decision_trees/minimal.json
+++ b/tedana/resources/decision_trees/minimal.json
@@ -14,7 +14,6 @@
         "variance explained"
     ],
     "intermediate_classifications": [
-        "lowvariance",
         "provisionalaccept",
         "provisionalreject"
     ],

--- a/tedana/resources/decision_trees/minimal.json
+++ b/tedana/resources/decision_trees/minimal.json
@@ -30,7 +30,7 @@
                 "decide_comps": "all"
             },
             "kwargs": {
-                "log_extra_info": "Initializing all classifications as unclassified and all rationales as blank",
+                "log_extra_info": "Initializing all classifications as unclassified and all classification tags as blank",
                 "log_extra_report": "",
                 "clear_classification_tags": true
             }

--- a/tedana/resources/decision_trees/minimal.json
+++ b/tedana/resources/decision_trees/minimal.json
@@ -20,6 +20,7 @@
     ],
     "classification_tags": [
         "Likely BOLD",
+        "Unlikely BOLD",
         "Low variance"
     ],
     "nodes": [
@@ -32,7 +33,7 @@
             "kwargs": {
                 "log_extra_info": "Initializing all classifications as unclassified and all rationales as blank",
                 "log_extra_report": "",
-                "clear_rationale": true
+                "clear_classification_tags": true
             }
         },
         {
@@ -47,7 +48,8 @@
             },
             "kwargs": {
                 "log_extra_info": "Reject if Kappa<Rho",
-                "log_extra_report": ""
+                "log_extra_report": "",
+                "tag_ifTrue": "Unlikely BOLD"
             }
         },
         {
@@ -62,7 +64,8 @@
             },
             "kwargs": {
                 "log_extra_info": "Reject if countsig_in S0clusters > T2clusters",
-                "log_extra_report": ""
+                "log_extra_report": "",
+                "tag_ifTrue": "Unlikely BOLD"
             }
         },
         {
@@ -77,7 +80,8 @@
             },
             "kwargs": {
                 "log_extra_info": "Reject if dice S0>T2",
-                "log_extra_report": ""
+                "log_extra_report": "",
+                "tag_ifTrue": "Unlikely BOLD"
             }
         },
         {
@@ -92,7 +96,8 @@
             },
             "kwargs": {
                 "log_extra_info": "Reject if T2fitdiff_invsout_ICAmap_Tstat<0",
-                "log_extra_report": ""
+                "log_extra_report": "",
+                "tag_ifTrue": "Unlikely BOLD"
             }
         },
         {
@@ -134,7 +139,8 @@
             "kwargs": {
                 "log_extra_info": "If kappa>elbow and kappa>3*rho accept even if rho>elbow",
                 "log_extra_report": "",
-                "right_scale": 3
+                "right_scale": 3,
+                "tag_ifTrue": "Likely BOLD"
             }
         },
         {
@@ -158,7 +164,7 @@
         {
             "functionname": "dec_variance_lessthan_thresholds",
             "parameters": {
-                "ifTrue": "lowvariance",
+                "ifTrue": "accepted",
                 "ifFalse": "nochange",
                 "decide_comps": [
                     "provisionalreject",
@@ -170,7 +176,8 @@
                 "log_extra_info": "",
                 "log_extra_report": "",
                 "single_comp_threshold": 0.1,
-                "all_comp_threshold": 1.0
+                "all_comp_threshold": 1.0,
+                "tag_ifTrue": "Low variance"
             }
         },
         {
@@ -182,7 +189,7 @@
             "kwargs": {
                 "log_extra_info": "",
                 "log_extra_report": "",
-                "clear_rationale": false
+                "tag": "Likely BOLD"
             }
         },
         {
@@ -197,7 +204,7 @@
             "kwargs": {
                 "log_extra_info": "",
                 "log_extra_report": "",
-                "clear_rationale": false
+                "tag": "Unlikely BOLD"
             }
         }
     ]

--- a/tedana/selection/ComponentSelector.py
+++ b/tedana/selection/ComponentSelector.py
@@ -205,7 +205,7 @@ def validate_tree(tree):
         nonstandard_labels = compclass.difference(all_classifications)
         if nonstandard_labels:
             LGR.warning(
-                "{} in node {} of the decision tree includes a nonstandard label".format(
+                "{} in node {} of the decision tree includes a classification label that was not predefined".format(
                     compclass, i
                 )
             )
@@ -217,9 +217,22 @@ def validate_tree(tree):
         nonstandard_labels = compclass.difference(all_decide_comps)
         if nonstandard_labels:
             LGR.warning(
-                "{} in node {} of the decision tree includes a nonstandard label".format(
-                    compclass, i
-                )
+                f"{complass} in node {i} of the decision tree includes a classification label that was not predefined"
+            )
+
+        tagset = set()
+        if "tag_ifTrue" in node.get("kwargs").keys():
+            tagset.update(set([node["kwargs"]["tag_ifTrue"]]))
+        if "tag_ifFalse" in node.get("kwargs").keys():
+            tagset.update(set([node["kwargs"]["tag_ifFalse"]]))
+        if "tag" in node.get("kwargs").keys():
+            tagset.update(set([node["kwargs"]["tag"]]))
+        undefined_classification_tags = tagset.difference(
+            set(tree.get("classification_tags"))
+        )
+        if undefined_classification_tags:
+            LGR.warning(
+                f"{tagset} in node {i} of the decision tree includes a classification tag that was not predefined"
             )
 
     if err_msg:
@@ -359,7 +372,7 @@ class ComponentSelector:
         self.nodes = tree_config["nodes"]
         self.necessary_metrics = set(tree_config["necessary_metrics"])
         self.intermediate_classifications = tree_config["intermediate_classifications"]
-        self.classification_tags = tree_config["classification_tags"]
+        self.classification_tags = set(tree_config["classification_tags"])
         self.cross_component_metrics = dict()
         self.used_metrics = set()
 

--- a/tedana/selection/ComponentSelector.py
+++ b/tedana/selection/ComponentSelector.py
@@ -306,12 +306,12 @@ class ComponentSelector:
         but there are common elements across most or all:
         decison_node_idx : :obj:`int`
             The decision tree functions are run as part of an ordered list.
-            This is the positional index for when this function was been run
+            This is the positional index for when this function was run
             as part of this list.
         used_metrics : :obj:`list[str]`
             A list of the metrics used in a node of the decision tree
         used_cross_component_metrics : :obj:`list[str]`
-            A list of cross component metrics used in the node of a decisiont ree
+            A list of cross component metrics used in the node of a decision tree
         node_label : :obj:`str`
             A brief label for what happens in this node that can be used in a decision
             tree summary table or flow chart.

--- a/tedana/selection/ComponentSelector.py
+++ b/tedana/selection/ComponentSelector.py
@@ -434,7 +434,7 @@ class ComponentSelector:
         self.are_only_necessary_metrics_used()
 
         self.are_all_components_accepted_or_rejected()
-
+        # TODO Remove this print statement once self.node is saved as a json
         print(self.nodes)
 
     def check_null(self, params, fcn):

--- a/tedana/selection/ComponentSelector.py
+++ b/tedana/selection/ComponentSelector.py
@@ -335,6 +335,13 @@ class ComponentSelector:
         """
         Initialize the class using the info specified in the json file `tree`
 
+        Any optional variables defined in the function call will be added to
+        the class structure. Several trees expect n_echos to be defined.
+        The full kundu tree also require n_vols (number of volumes) to be
+        defined. An example initialization with these options would look like
+        selector = ComponentSelector(tree, comptable, n_echos=n_echos,
+        n_vols=n_vols)
+
         Returns
         -------
         The class structure with the following fields loaded from tree:

--- a/tedana/selection/ComponentSelector.py
+++ b/tedana/selection/ComponentSelector.py
@@ -245,7 +245,7 @@ def validate_tree(tree):
 class ComponentSelector:
     """
     Classifies components based on specified `tree` when the class is initialized
-    and then the `component_select` function is called.
+    and then the `select` function is called.
     The expected output of running a decision tree is that every component
     will be classified as 'accepted', or 'rejected'.
 
@@ -384,7 +384,7 @@ class ComponentSelector:
         self.cross_component_metrics = dict()
         self.used_metrics = set()
 
-    def component_select(self):
+    def select(self):
         """
         Parse the parameters used to call each function in the component
         selection decision tree and run the functions to classify components

--- a/tedana/selection/ComponentSelector.py
+++ b/tedana/selection/ComponentSelector.py
@@ -116,7 +116,7 @@ def validate_tree(tree):
         "classification_tags",
         "nodes",
     ]
-    defaults = {"DT_class", "decision_node_idx"}
+    defaults = {"selector", "decision_node_idx"}
     default_classifications = {"nochange", "accepted", "rejected", "unclassified"}
     default_decide_comps = {"all", "accepted", "rejected", "unclassified"}
 
@@ -221,7 +221,7 @@ def validate_tree(tree):
     return tree
 
 
-class DecisionTree:
+class ComponentSelector:
     """
     Classifies components based on specified `tree` when the class is initialized
     and then the `run` function is called.
@@ -250,7 +250,7 @@ class DecisionTree:
     Additional Parameters
     ---------------------
     Any parameter that is used by a decision tree node function can be passed
-    as a parameter of DecisionTree class initialization function or can be
+    as a parameter of ComponentSelector class initialization function or can be
     included in the json file that defines the decision tree. If a parameter
     is set in the json file, that will take precedence. As a style rule, a
     parameter that is the same regardless of the inputted data should be
@@ -333,7 +333,7 @@ class DecisionTree:
         self.cross_component_metrics = dict()
         self.used_metrics = []
 
-    def run(self):
+    def component_select(self):
         """
         Parse the parameters used to call each function in the component
         selection decision tree and run the functions to classify components
@@ -428,7 +428,7 @@ class DecisionTree:
                         )
                         + "If {} is dataset specific, it should be "
                         "defined in the ".format(key) + " initialization of "
-                        "DecisionTree. If it is fixed regardless of dataset, it "
+                        "ComponentSelector. If it is fixed regardless of dataset, it "
                         "should be defined in the json file that defines the "
                         "decision tree."
                     )

--- a/tedana/selection/DecisionTree.py
+++ b/tedana/selection/DecisionTree.py
@@ -319,15 +319,17 @@ class DecisionTree:
         )
 
         self.__dict__.update(kwargs)
-        self.config = load_config(self.tree)
+        tree_config = load_config(self.tree)
 
-        LGR.info("Performing component selection with " + self.config["tree_id"])
-        LGR.info(self.config.get("info", ""))
-        RepLGR.info(self.config.get("report", ""))
-        RefLGR.info(self.config.get("refs", ""))
+        LGR.info("Performing component selection with " + tree_config["tree_id"])
+        LGR.info(tree_config.get("info", ""))
+        RepLGR.info(tree_config.get("report", ""))
+        RefLGR.info(tree_config.get("refs", ""))
 
-        self.nodes = self.config["nodes"]
-        self.necessary_metrics = self.config["necessary_metrics"]
+        self.nodes = tree_config["nodes"]
+        self.necessary_metrics = tree_config["necessary_metrics"]
+        self.intermediate_classifications = tree_config["intermediate_classifications"]
+        self.classification_tags = tree_config["classification_tags"]
         self.cross_component_metrics = dict()
         self.used_metrics = []
 
@@ -388,12 +390,6 @@ class DecisionTree:
         self.component_table = clean_dataframe(self.component_table)
         self.are_only_necessary_metrics_used(used_metrics)
         print(self.nodes)
-        return (
-            self.component_table,
-            self.cross_component_metrics,
-            self.component_status_table,
-            self.nodes,
-        )
 
     def check_necessary_metrics(self):
         used_metrics = set()

--- a/tedana/selection/DecisionTree.py
+++ b/tedana/selection/DecisionTree.py
@@ -127,7 +127,7 @@ def validate_tree(tree):
         except AssertionError:
             err_msg += "Decision tree missing required info: {}\n".format(k)
 
-    # Combine the default classificaitons with the user inputted classifications
+    # Combine the default classifications with the user inputted classifications
     all_classifications = set(tree.get("intermediate_classifications")) | set(
         default_classifications
     )

--- a/tedana/selection/DecisionTree.py
+++ b/tedana/selection/DecisionTree.py
@@ -106,7 +106,7 @@ def validate_tree(tree):
 
     # Set the fields that should always be present
     err_msg = ""
-    tree_info = [
+    tree_expected_keys = [
         "tree_id",
         "info",
         "report",
@@ -121,11 +121,19 @@ def validate_tree(tree):
     default_decide_comps = {"all", "accepted", "rejected", "unclassified"}
 
     # Confirm that the required fields exist
-    for k in tree_info:
-        try:
-            assert tree.get(k) is not None
-        except AssertionError:
-            err_msg += "Decision tree missing required info: {}\n".format(k)
+    missing_keys = set(tree_expected_keys) - set(tree.keys())
+    if missing_keys:
+        # If there are missing keys, this function may crash before the end.
+        # End function here with a clear error message rather than adding
+        # `if assert tree.get()` statements before every section
+        raise TreeError("\n" + f"Decision tree missing required fields: {missing_keys}")
+
+    # Warn if unused fields exist
+    unused_keys = set(tree.keys()) - set(tree_expected_keys)
+    if unused_keys:
+        LGR.warning(
+            f"Decision tree includes fields that are not used or logged {unused_keys}"
+        )
 
     # Combine the default classifications with the user inputted classifications
     all_classifications = set(tree.get("intermediate_classifications")) | set(

--- a/tedana/selection/_utils.py
+++ b/tedana/selection/_utils.py
@@ -15,27 +15,31 @@ RefLGR = logging.getLogger("REFERENCES")
 # Functions that are used for interacting with comptable
 
 
-def selectcomps2use(comptable, decide_comps):
+def selectcomps2use(DT_class, decide_comps):
     """
-    Give a list of components that fit a classification types
+    Give a list of component numbers that fit the classification types in
+    decide_comps. Also pulls out and returns component_table from within
+    DT_class
     Since 'all' converts string to boolean, it will miss components with
     no classification. This means, in the initialization of comptree, all
     components need to be labeled as unclassified, NOT empty
-    WILL NEED TO ADD NUMBER INDEXING TO selectcomps2use
+    MAY WANT TO ADD NUMBER INDEXING TO selectcomps2use SO THAT USERS CAN
+    SELECT COMPONENTS BY NUMBER RATHER THAN LABEL
     """
+    component_table = DT_class.component_table
     if type(decide_comps) == str:
         decide_comps = [decide_comps]
     if decide_comps[0] == "all":
         # All components with any string in the classification field
         # are set to True
-        comps2use = list(range(comptable.shape[0]))
+        comps2use = list(range(component_table.shape[0]))
     # elif (type(decide_comps) == str):
     #    comps2use = comptable.index[comptable['classification'] == decide_comps].tolist()
     elif (type(decide_comps) == list) and (type(decide_comps[0]) == str):
         comps2use = []
         for didx in range(len(decide_comps)):
-            newcomps2use = comptable.index[
-                comptable["classification"] == decide_comps[didx]
+            newcomps2use = component_table.index[
+                component_table["classification"] == decide_comps[didx]
             ].tolist()
             comps2use = list(set(comps2use + newcomps2use))
     else:
@@ -48,7 +52,7 @@ def selectcomps2use(comptable, decide_comps):
     if not comps2use:
         comps2use = None
 
-    return comps2use
+    return comps2use, component_table
 
 
 def change_comptable_classifications(
@@ -249,9 +253,9 @@ def log_decision_tree_step(
     ifFalse=None,
 ):
     """
-        Logging text to add for every decision tree calculation
-        If decide_comps is not None, then the output will be ugly
-        if numTrue, numFalse, ifTrue, and ifFalse are not defined
+    Logging text to add for every decision tree calculation
+    If decide_comps is not None, then the output will be ugly
+    if numTrue, numFalse, ifTrue, and ifFalse are not defined
     """
 
     if comps2use is None:

--- a/tedana/selection/_utils.py
+++ b/tedana/selection/_utils.py
@@ -126,18 +126,13 @@ def change_comptable_classifications(
         component_table["classification_tags"] will be updated to include any
         new tags. Each tag should appear only once in the string and tags will
         be separated by commas.
-    If a classification is changed away from accepted or rejected and
-    dont_warn_reclassify is False, then a warning is logged
+    numTrue, numFalse: :obj:`int`
+        The number of True and False components in decision_boolean
 
     Note
     ----
-    TODO: May want to add a check here so that, if a component classification
-    is changed away from accepted or reject to something else, throw a warning.
-    A user would have the power to change component labels in any order, but
-    the ideal is that once something is accepted or rejected, that shouldn't
-    change. If this is added, then there should be an option to override the
-    warning. That override would be necessary when manual_classify is used to
-    remove all classification info at the start of a decision tree.
+    If a classification is changed away from accepted or rejected and
+    dont_warn_reclassify is False, then a warning is logged
     """
 
     selector = comptable_classification_changer(
@@ -151,7 +146,9 @@ def change_comptable_classifications(
         f"Node {selector.current_node_idx}"
     ] = selector.component_table["classification"]
 
-    return selector
+    numTrue = decision_boolean.sum()
+    numFalse = np.logical_not(decision_boolean).sum()
+    return selector, numTrue, numFalse
 
 
 def comptable_classification_changer(

--- a/tedana/selection/_utils.py
+++ b/tedana/selection/_utils.py
@@ -55,7 +55,9 @@ def selectcomps2use(selector, decide_comps):
     return comps2use, component_table
 
 
-def change_comptable_classifications(selector, ifTrue, ifFalse, decision_boolean):
+def change_comptable_classifications(
+    selector, ifTrue, ifFalse, decision_boolean, tag_ifTrue=None, tag_ifFalse=None
+):
     """
     Given information on whether a decision critereon is true or false for each component
     change or don't change the component classification
@@ -79,15 +81,33 @@ def change_comptable_classifications(selector, ifTrue, ifFalse, decision_boolean
     if ifTrue != "nochange":
         changeidx = decision_boolean.index[np.asarray(decision_boolean)]
         selector.component_table.loc[changeidx, "classification"] = ifTrue
-        # comptable.loc[changeidx, "rationale"] += (
-        #     decision_node_idx_str + ": " + ifTrue + "; "
-        # )
+        if tag_ifTrue:
+            for idx in changeidx:
+                tmpstr = selector.component_table.loc[idx, "classification_tags"]
+                if tmpstr != "":
+                    tmpset = set(tmpstr.split(","))
+                    tmpset.update([tag_ifTrue])
+                else:
+                    tmpset = set([tag_ifTrue])
+                selector.component_table.loc[idx, "classification_tags"] = ",".join(
+                    str(s) for s in tmpset
+                )
+
     if ifFalse != "nochange":
         changeidx = decision_boolean.index[~np.asarray(decision_boolean)]
         selector.component_table.loc[changeidx, "classification"] = ifFalse
-        # comptable.loc[changeidx, "rationale"] += (
-        #     decision_node_idx_str + ": " + ifFalse + "; "
-        # )
+        if tag_ifFalse:
+            for idx in changeidx:
+                tmpstr = selector.component_table.loc[idx, "classification_tags"]
+                if tmpstr != "":
+                    tmpset = set(tmpstr.split(","))
+                    tmpset.update([tag_ifFalse])
+                else:
+                    tmpset = set([tag_ifFalse])
+                selector.component_table.loc[idx, "classification_tags"] = ",".join(
+                    str(s) for s in tmpset
+                )
+
     selector.component_status_table[
         f"Node {selector.current_node_idx}"
     ] = selector.component_table["classification"]

--- a/tedana/selection/_utils.py
+++ b/tedana/selection/_utils.py
@@ -56,7 +56,7 @@ def selectcomps2use(DT_class, decide_comps):
 
 
 def change_comptable_classifications(
-    comptable, ifTrue, ifFalse, decision_boolean, decision_node_idx_str
+    DT_class, ifTrue, ifFalse, decision_boolean, decision_node_idx
 ):
     """
     Given information on whether a decision critereon is true or false for each component
@@ -80,21 +80,24 @@ def change_comptable_classifications(
 
     if ifTrue != "nochange":
         changeidx = decision_boolean.index[np.asarray(decision_boolean)]
-        comptable.loc[changeidx, "classification"] = ifTrue
-        comptable.loc[changeidx, "rationale"] += (
-            decision_node_idx_str + ": " + ifTrue + "; "
-        )
+        DT_class.component_table.loc[changeidx, "classification"] = ifTrue
+        # comptable.loc[changeidx, "rationale"] += (
+        #     decision_node_idx_str + ": " + ifTrue + "; "
+        # )
     if ifFalse != "nochange":
         changeidx = decision_boolean.index[~np.asarray(decision_boolean)]
-        comptable.loc[changeidx, "classification"] = ifFalse
-        comptable.loc[changeidx, "rationale"] += (
-            decision_node_idx_str + ": " + ifFalse + "; "
-        )
+        DT_class.component_table.loc[changeidx, "classification"] = ifFalse
+        # comptable.loc[changeidx, "rationale"] += (
+        #     decision_node_idx_str + ": " + ifFalse + "; "
+        # )
+    DT_class.component_status_table[
+        f"Node {decision_node_idx}"
+    ] = DT_class.component_table["classification"]
 
     # decision_tree_steps[-1]['numtrue'] = (decision_boolean is True).sum()
     # decision_tree_steps[-1]['numfalse'] = (decision_boolean is False).sum()
 
-    return comptable  # , decision_tree_steps
+    return DT_class  # , decision_tree_steps
 
 
 def clean_dataframe(comptable):

--- a/tedana/selection/_utils.py
+++ b/tedana/selection/_utils.py
@@ -12,20 +12,45 @@ LGR = logging.getLogger("GENERAL")
 RepLGR = logging.getLogger("REPORT")
 RefLGR = logging.getLogger("REFERENCES")
 
-# Functions that are used for interacting with comptable
+##############################################################
+# Functions that are used for interacting with component_table
+##############################################################
 
 
 def selectcomps2use(selector, decide_comps):
     """
     Give a list of component numbers that fit the classification types in
-    decide_comps. Also pulls out and returns component_table from within
-    selector.
-    Since 'all' converts string to boolean, it will miss components with
-    no classification. This means, in the initialization of comptree, all
-    components need to be labeled as unclassified, NOT empty
-    TODO: May want to add number indexing to selectcomps2use so that users
-    can selection componetnes by number rather than label
+    decide_comps.
+
+    Parameters
+    ----------
+    selector: :obj:`tedana.selection.ComponentSelector`
+        Only uses the component_table in this object
+    decide_comps: :obj:`str` or :obj:`list[str]` or :obj:`list[int]`
+        This is string or a list of strings describing what classifications
+        of components to operate on, using default or intermediate_classification
+        labels. For example: decide_comps='unclassified' means to operate only on
+        unclassified components. The label 'all' will operate on all components
+        regardess of classification. This can also be used to pass through a list
+        of component indices to comps2use
+
+    Returns
+    -------
+    comps2use: :obj:`list[int]`
+        A list of component indices that should be used by a function
+    component_table : (C x M) :obj:`pandas.DataFrame`
+        Reference to component metric table in `selector`. One row for each
+        component, with a column for each metric. Since the component table
+        is assigned rather than copied, changes to this variable will change
+        `selector.component_table`
+
+     Note
+    ----
+    TODO: Number indexing should work here, but validator would not currently allow
+    numbers to be assigned to a node in the ComponentSelector object. May want to make
+    sure this option is acceissble through the class.
     """
+
     component_table = selector.component_table
     if type(decide_comps) == str:
         decide_comps = [decide_comps]
@@ -33,8 +58,7 @@ def selectcomps2use(selector, decide_comps):
         # All components with any string in the classification field
         # are set to True
         comps2use = list(range(component_table.shape[0]))
-    # elif (type(decide_comps) == str):
-    #    comps2use = comptable.index[comptable['classification'] == decide_comps].tolist()
+
     elif (type(decide_comps) == list) and (type(decide_comps[0]) == str):
         comps2use = []
         for didx in range(len(decide_comps)):
@@ -62,21 +86,47 @@ def change_comptable_classifications(
     Given information on whether a decision critereon is true or false for each component
     change or don't change the component classification
 
+    Parameters
+    ----------
+    selector: :obj:`tedana.selection.ComponentSelector`
+        The attributes used are component_table, component_status_table, and
+        current_node_idx
+    ifTrue, ifFalse: :obj:`str`
+        If the condition in this step is true or false, give the component
+        the label in this string. Options are 'accepted', 'rejected',
+        'nochange', or intermediate_classification labels predefined in the
+        decision tree. If 'nochange' then don't change the current component
+        classification
+    decision_boolean: :obj:`pd.Series(bool)`
+        A dataframe column of equal length to component_table where each value
+        is True or False.
+    tag_ifTrue, tag_ifFalse: :obj:`str`
+        A string containing a label in classification_tags that will be added to
+        the classification_tags column in component_table if a component is
+        classified as true or false. default=None
+
+    Returns
+    -------
+    selector: :obj:`tedana.selection.ComponentSelector`
+        component_table["classifications"] will reflect any new
+        classifications.
+        component_status_table will have a new column titled
+        "Node current_node_idx" that is a copy of the updated classifications
+        column.
+        component_table["classification_tags"] will be updated to include any
+        new tags. Each tag should appear only once in the string and tags will
+        be separated by commas.
+
     Note
     ----
-    May want to add a check here so that, if a component classification is changed from
-    accepted, rejected, or ignored, to something else, throw a warning. A user would have the power
-    to change component labels in any order, but the ideal is that once something is assigned
-    as accepted, rejected, or ignored, those are final classifications that should not be changed.
-    If this is added, then there should be an option to override the warning. That override
-    would be necessary when manual_classify is used to remove all classification info at the
-    start of a decision tree. It also might be useful to have an override for ignore.
-    The use case for this would be, if the total explained variance of all the ignored components
-    is above a threshold (i.e >5% of accepted explained variance) then move the highest variance
-    ignored components with rho/kappa>a threshold form ignore to reject
+    TODO: May want to add a check here so that, if a component classification
+    is changed away from accepted or reject to something else, throw a warning.
+    A user would have the power to change component labels in any order, but
+    the ideal is that once something is accepted or rejected, that shouldn't
+    change. If this is added, then there should be an option to override the
+    warning. That override would be necessary when manual_classify is used to
+    remove all classification info at the start of a decision tree.
     """
-    # print(('ifTrue={}, ifFalse={}, decision_node_idx_str{}').format(
-    #    ifTrue, ifFalse, decision_node_idx_str))
 
     if ifTrue != "nochange":
         changeidx = decision_boolean.index[np.asarray(decision_boolean)]
@@ -112,37 +162,48 @@ def change_comptable_classifications(
         f"Node {selector.current_node_idx}"
     ] = selector.component_table["classification"]
 
-    # decision_tree_steps[-1]['numtrue'] = (decision_boolean is True).sum()
-    # decision_tree_steps[-1]['numfalse'] = (decision_boolean is False).sum()
-
-    return selector  # , decision_tree_steps
+    return selector
 
 
-def clean_dataframe(comptable):
+def clean_dataframe(component_table):
     """
-    Reorder columns in component table so "rationale" and "classification" are
-    last and remove trailing semicolons from rationale column.
+    Reorder columns in component table so that "classification"
+    and "classification_tags" are last.
+
+    Parameters
+    ----------
+    component_table : (C x M) :obj:`pandas.DataFrame`
+        Component metric table. One row for each component, with a column for
+        each metric
+
+    Returns
+    -------
+    component_table : (C x M) :obj:`pandas.DataFrame`
+        Same data as input, but the final two columns are "classification"
+        and "classification_tags"
     """
     cols_at_end = ["classification", "rationale"]
-    comptable = comptable[
-        [c for c in comptable if c not in cols_at_end]
-        + [c for c in cols_at_end if c in comptable]
+    component_table = component_table[
+        [c for c in component_table if c not in cols_at_end]
+        + [c for c in cols_at_end if c in component_table]
     ]
-    # comptable["rationale"] = comptable["rationale"].str.rstrip(";")
-    return comptable
+
+    return component_table
 
 
-# Functions that validate inputted parameters or other processing steps
+#################################################
+# Functions to validate inputs or log information
+#################################################
 
 
-def confirm_metrics_exist(comptable, necessary_metrics, function_name=None):
+def confirm_metrics_exist(component_table, necessary_metrics, function_name=None):
     """
     Confirm that all metrics declared in necessary_metrics are
     already included in comptable.
 
     Parameters
     ----------
-    comptable : (C x M) :obj:`pandas.DataFrame`
+    component_table : (C x M) :obj:`pandas.DataFrame`
             Component metric table. One row for each component, with a column for
             each metric. The index should be the component number.
     necessary_metrics : :obj:`set` a set of strings of metrics
@@ -152,115 +213,32 @@ def confirm_metrics_exist(comptable, necessary_metrics, function_name=None):
     Returns
     -------
     metrics_exist : :obj:`bool`
-            True if all metrics in necessary_metrics are on the comptable
-            False if one or more metrics are in necessary_metrics, but not in the comptable
-    missing_metrics : :obj:`list`
-            if metrics_exist then this is a list of strings containing the metric
-            names in necessary_metrics that aren't in the comptable
-            if not metrics_exist then an empty list
+            True if all metrics in necessary_metrics are in component_table
 
-    If metrics_exist is false then print an error and end the program
+    If metrics_exist is False then raise an error and end the program
 
     Notes
     -----
     This doesn't check if there are data in each metric's column, just that
     the columns exist. Also, this requires identical strings for the names
-    of the metrics in necessary_metrics and the column labels in comptable
+    of the metrics in necessary_metrics and the column labels in component_table
     """
 
-    missing_metrics = necessary_metrics - set(comptable.columns)
+    missing_metrics = necessary_metrics - set(component_table.columns)
     metrics_exist = len(missing_metrics) > 0
     if metrics_exist is True:
-        if function_name is not None:
-            error_msg = (
-                f"Necessary metrics for {function_name}: "
-                f"{necessary_metrics}. "
-                f"Comptable metrics: {set(comptable.columns)}. "
-                f"MISSING METRICS: {missing_metrics}."
-            )
-        else:
-            error_msg = (
-                "Necessary metrics for unknown function: "
-                f"{necessary_metrics}. "
-                f"Comptable metrics: {set(comptable.columns)}. "
-                f"MISSING METRICS: {missing_metrics}."
-            )
+        if function_name is None:
+            function_name = "unknown function"
 
+        error_msg = (
+            f"Necessary metrics for {function_name}: "
+            f"{necessary_metrics}. "
+            f"Comptable metrics: {set(component_table.columns)}. "
+            f"MISSING METRICS: {missing_metrics}."
+        )
         raise ValueError(error_msg)
 
-    return metrics_exist, missing_metrics
-
-
-# def are_only_necessary_metrics_used(used_metrics, necessary_metrics, function_name):
-#     """
-#     Checks if all metrics that are declared as necessary are actually used and
-#     if any used_metrics weren't explicitly declared. If either of these happen,
-#     a warning is added to the logger that notes which metrics weren't declared
-#     or used.
-
-#     Parameters
-#     ----------
-#     used_metrics: :obj:`list`
-#             A list of strings of the metric names that were used in the
-#             decision tree
-#     necessary_metrics: :obj:`list`
-#             A list of strings of the metric names that were declared
-#             to be used in the decision tree
-#     function_name: :obj:`str`
-#             The function name for the decision tree that was run
-
-#     Returns
-#     -------
-#     A warning that includes a list of metrics that were used, but
-#     not declared or declared, but not used. If only declared metrics
-#     where used, then this function has no output
-#     """
-#     onlyin_used_metrics = np.setdiff1d(used_metrics, necessary_metrics)
-#     if not onlyin_used_metrics:
-#         LGR.warning(function_name + " uses the following metrics that are not "
-#                     "declared as necessary metrices: " + str(onlyin_used_metrics))
-
-#     onlyin_necessary_metrics = np.setdiff1d(necessary_metrics, used_metrics)
-#     if not onlyin_necessary_metrics:
-#         LGR.warning(function_name + " declared the following metrics as necessary "
-#                     "but does not use them: " + str(onlyin_necessary_metrics))
-
-# Functions that edit decision_tree_steps
-
-
-def new_decision_node_info(
-    decision_tree_steps,
-    function_name,
-    metrics_used,
-    ifTrue,
-    ifFalse,
-    additionalparameters=None,
-):
-    """
-    create a new node that logs steps in the decision tree
-    """
-
-    # ADD ERROR TESTING SO THAT A CRASH FROM A MISSING VARIABLE IS INTELLIGENTLY LOGGED
-    tmp_decision_tree = {
-        "nodeidx": None,
-        "function_name": function_name,
-        "metrics_used": metrics_used,
-        "ifTrue": ifTrue,
-        "ifFalse": ifFalse,
-        "additionalparameters": additionalparameters,
-        "report_extra_log": [],  # optionally defined by user
-        "numfalse": [],  # will be filled in at runtime
-        "numtrue": [],  # will be filled in at runtime
-    }
-
-    if decision_tree_steps is None:
-        decision_tree_steps = [tmp_decision_tree]
-        decision_tree_steps["nodeidx"] = 1
-    else:
-        tmp_decision_tree["nodeidx"] = len(decision_tree_steps) + 1
-        decision_tree_steps.append(tmp_decision_tree)
-
-    return decision_tree_steps
+    return metrics_exist
 
 
 def log_decision_tree_step(
@@ -275,8 +253,35 @@ def log_decision_tree_step(
 ):
     """
     Logging text to add for every decision tree calculation
-    If decide_comps is not None, then the output will be ugly
-    if numTrue, numFalse, ifTrue, and ifFalse are not defined
+
+    Parameters
+    ----------
+    function_name_idx: :obj:`str`
+        The name of the function that should be logged. By convention, this
+        be "Step current_node_idx: function_name"
+    comps2use: :obj:`list[int]`
+        A list of component indices that should be used by a function.
+        Only used to report no components found if empty and report
+        the number of components found if not empty.
+    decide_comps: :obj:`str` or :obj:`list[str]` or :obj:`list[int]`
+        This is string or a list of strings describing what classifications
+        of components to operate on. Only used in this function to report
+        its contents if no components with these classifications were found
+    numTrue, numFalse: :obj:`int`
+        The number of components classified as True or False
+    ifTrue, ifFalse: :obj:`str`
+        If a component is true or false, the classification to assign that
+        component
+    calc_outputs: :obj:`bool`
+        True if the function being logged calculated new cross component
+        metrics. If true, then log the metrics calculated and their values
+
+    Returns
+    -------
+    Information is added to the LGR.info logger. This either logs that
+    nothing was changed, the number of components classified as true or
+    false and what they changed to, or the cross component metrics that were
+    calculated
     """
 
     if comps2use is None:
@@ -300,8 +305,21 @@ def log_decision_tree_step(
 
 def log_classification_counts(decision_node_idx, component_table):
     """
-    Log the total counts for each component classification in the comptable
-    That is something like 'Total component classifications: 10 accepted, 5 ignored, 8 rejected'
+    Log the total counts for each component classification in component_table
+
+    Parameters
+    ----------
+    decision_node_idx : :obj:`int`
+        The index number for the function in the decision tree that just
+        finished executing
+    component_table : (C x M) :obj:`pandas.DataFrame`
+        Component metric table. One row for each component, with a column for
+        each metric. Only the "classification" column is usd in this function
+
+    Returns
+    -------
+    The info logger will add a line like:
+    'Step 4: Total component classifications: 10 accepted, 5 provisionalreject, 8 rejected'
     """
 
     (classification_labels, label_counts) = np.unique(
@@ -315,112 +333,9 @@ def log_classification_counts(decision_node_idx, component_table):
     LGR.info(out_str)
 
 
-def create_dnode_outputs(
-    decision_node_idx,
-    used_metrics,
-    node_label,
-    numTrue,
-    numFalse,
-    n_echos=None,
-    n_vols=None,
-    kappa_elbow=None,
-    rho_elbow=None,
-    kappa_only=None,
-    rho_only=None,
-    num_prov_accept=None,
-    max_good_meanmetricrank=None,
-    varex_threshold=None,
-    low_perc=None,
-    high_perc=None,
-    extend_factor=None,
-    restrict_factor=None,
-    prev_X_steps=None,
-    num_acc_guess=None,
-):
-    """
-    Take several parameters that should be output from each decision node function
-    and put them in a dictionary under the key 'outputs' When the decision is output
-    as part of the decision tree class, this will be added to the dictionary with
-    parameters that called the function with all the outputs under the 'outputs' key.
-
-    Parameters
-    ----------
-    Required parameters
-    decison_node_idx : :obj:`int`
-        The decision tree function are run as part of an ordered list.
-        This is the positional index for when this function has been run
-        as part of this list.
-    used_metrics: :obj:`list[str]`
-        A list of all metrics from the comptable header used within this function.
-        Note, this must be a list even if only one metric is used
-    node_label: :obj:`str`
-        A brief label for what happens in this node that can be used in a decision
-        tree summary table or flow chart.
-    numTrue, numFalse: :obj:`int`
-        The number of components that were classified as true or false respectively
-    in this decision tree step.
-
-    Optional parameters that are ignored, if None
-    n_echos: :obj:`int`
-        The number of echos in the multi-echo data
-    n_vols: :obj:`int`
-        The number of volumes (time points) in the fMRI data
-    kappa_elbow: :obj:`float`
-        The kappa threshold below which components should be rejected or ignored
-    rho_elbow: :obj:`float`
-        The rho threshold above which components should be rejected or ignored
-    kappa_only: :obj:`bool`, optional
-            Only use the kappa>kappa_elbow threshold. default=False
-    rho_only: :obj:`bool`, optional
-            Only use the rho>rho_elbow threshold. default=False
-
-
-    Returns
-    -------
-    dnode_outputs: :obj:`dict`
-        A dict that contains the inputted parameters that are not 'None'
-    """
-
-    dnode_outputs = {
-        "outputs": {
-            "decision_node_idx": decision_node_idx,
-            "used_metrics": used_metrics,
-            "node_label": node_label,
-            "numTrue": numTrue,
-            "numFalse": numFalse,
-        }
-    }
-    if n_echos:
-        dnode_outputs["outputs"].update({"n_echos": n_echos})
-    if n_vols:
-        dnode_outputs["outputs"].update({"n_vols": n_vols})
-    if kappa_elbow:
-        dnode_outputs["outputs"].update({"kappa_elbow": kappa_elbow})
-    if rho_elbow:
-        dnode_outputs["outputs"].update({"rho_elbow": rho_elbow})
-    if high_perc:
-        dnode_outputs["outputs"].update({"high_perc": high_perc})
-    if low_perc:
-        dnode_outputs["outputs"].update({"low_perc": low_perc})
-    if max_good_meanmetricrank:
-        dnode_outputs["outputs"].update(
-            {"max_good_meanmetricrank": max_good_meanmetricrank}
-        )
-    if varex_threshold:
-        dnode_outputs["outputs"].update({"varex_threshold": varex_threshold})
-    if num_prov_accept:
-        dnode_outputs["outputs"].update({"num_prov_accept": num_prov_accept})
-    if restrict_factor:
-        dnode_outputs["outputs"].update({"restrict_factor": num_prov_accept})
-    if prev_X_steps:
-        dnode_outputs["outputs"].update({"prev_X_steps": num_prov_accept})
-    if num_acc_guess:
-        dnode_outputs["outputs"].update({"num_acc_guess": num_prov_accept})
-
-    return dnode_outputs
-
-
+#######################################################
 # Calculations that are used in decision tree functions
+#######################################################
 
 
 def getelbow_cons(arr, return_val=False):

--- a/tedana/selection/_utils.py
+++ b/tedana/selection/_utils.py
@@ -128,7 +128,7 @@ def clean_dataframe(comptable):
         [c for c in comptable if c not in cols_at_end]
         + [c for c in cols_at_end if c in comptable]
     ]
-    comptable["rationale"] = comptable["rationale"].str.rstrip(";")
+    # comptable["rationale"] = comptable["rationale"].str.rstrip(";")
     return comptable
 
 

--- a/tedana/selection/_utils.py
+++ b/tedana/selection/_utils.py
@@ -23,8 +23,8 @@ def selectcomps2use(selector, decide_comps):
     Since 'all' converts string to boolean, it will miss components with
     no classification. This means, in the initialization of comptree, all
     components need to be labeled as unclassified, NOT empty
-    MAY WANT TO ADD NUMBER INDEXING TO selectcomps2use SO THAT USERS CAN
-    SELECT COMPONENTS BY NUMBER RATHER THAN LABEL
+    TODO: May want to add number indexing to selectcomps2use so that users
+    can selection componetnes by number rather than label
     """
     component_table = selector.component_table
     if type(decide_comps) == str:
@@ -252,6 +252,7 @@ def log_decision_tree_step(
     numFalse=None,
     ifTrue=None,
     ifFalse=None,
+    calc_outputs=None,
 ):
     """
     Logging text to add for every decision tree calculation
@@ -261,29 +262,31 @@ def log_decision_tree_step(
 
     if comps2use is None:
         LGR.info(
-            (
-                "{} not applied because no remaining components were "
-                "classified as {}"
-            ).format(function_name_idx, decide_comps)
+            f"{function_name_idx} not applied because no remaining components were "
+            "classified as {decide_comps}"
         )
-    else:
+    if ifTrue or ifFalse:
         LGR.info(
-            (
-                "{} applied to {} components. " "{} True -> {}. " "{} False -> {}."
-            ).format(
-                function_name_idx, len(comps2use), numTrue, ifTrue, numFalse, ifFalse
-            )
+            f"{function_name_idx} applied to {len(comps2use)} components. "
+            "{numTrue} True -> {ifTrue}. "
+            "{numFalse} False -> {ifFalse}."
         )
+    if calc_outputs:
+        calc_summaries = [
+            f"{metric_name}={calc_outputs[metric_name]}"
+            for metric_name in calc_outputs["calc_cross_comp_metrics"]
+        ]
+        LGR.info(f"{function_name_idx} calculated: {', '.join(calc_summaries)}")
 
 
-def log_classification_counts(decision_node_idx, comptable):
+def log_classification_counts(decision_node_idx, component_table):
     """
     Log the total counts for each component classification in the comptable
     That is something like 'Total component classifications: 10 accepted, 5 ignored, 8 rejected'
     """
 
     (classification_labels, label_counts) = np.unique(
-        comptable["classification"].values, return_counts=True
+        component_table["classification"].values, return_counts=True
     )
     label_summaries = [
         f"{label_counts[i]} {label}" for i, label in enumerate(classification_labels)
@@ -517,20 +520,10 @@ def kappa_elbow_kundu(comptable, n_echos):
                 getelbow(comptable["kappa"], return_val=True),
             )
         )
-        LGR.info(
-            (
-                "Calculating kappa elbow based min of all and nonsig "
-                f"components. Kappa elbow is {kappa_elbow}"
-            )
-        )
+        LGR.info(("Calculating kappa elbow based on min of all and nonsig components."))
     else:
         kappa_elbow = getelbow(comptable["kappa"], return_val=True)
-        LGR.info(
-            (
-                "Calculating kappa elbow based on all components. "
-                f"Kappa elbow is {kappa_elbow}"
-            )
-        )
+        LGR.info(("Calculating kappa elbow based on all components."))
 
     return kappa_elbow
 

--- a/tedana/selection/_utils.py
+++ b/tedana/selection/_utils.py
@@ -149,9 +149,8 @@ def confirm_metrics_exist(comptable, necessary_metrics, function_name=None):
     """
 
     missing_metrics = necessary_metrics - set(comptable.columns)
-    metrics_exist = len(missing_metrics) == 0
-
-    if metrics_exist is False:
+    metrics_exist = len(missing_metrics) > 0
+    if metrics_exist is True:
         if function_name is not None:
             error_msg = (
                 f"Necessary metrics for {function_name}: "

--- a/tedana/selection/_utils.py
+++ b/tedana/selection/_utils.py
@@ -259,7 +259,7 @@ def clean_dataframe(component_table):
         Same data as input, but the final two columns are "classification"
         and "classification_tags"
     """
-    cols_at_end = ["classification", "rationale"]
+    cols_at_end = ["classification", "classification_tags"]
     component_table = component_table[
         [c for c in component_table if c not in cols_at_end]
         + [c for c in cols_at_end if c in component_table]

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -124,14 +124,7 @@ def manual_classify(
 ):
     """
     Explicitly assign a classifictation, defined in new_classification,
-    to all the components in decide_comps. This was designed with three use
-    cases in mind:
-    1. Set the classifications of all components to unclassified for the first
-    node of a decision tree. clear_classification_tags=True is recommended for
-    this use case
-    2. Shift all components between classifications, such as provisionalaccept
-    to accepted for the penultimate node in the decision tree.
-    3. Manually re-classify components by number based on user observations.
+    to all the components in decide_comps.
 
     Parameters
     ----------
@@ -162,6 +155,15 @@ def manual_classify(
 
     Note
     ----
+    This was designed with three use
+    cases in mind:
+    1. Set the classifications of all components to unclassified for the first
+    node of a decision tree. clear_classification_tags=True is recommended for
+    this use case
+    2. Shift all components between classifications, such as provisionalaccept
+    to accepted for the penultimate node in the decision tree.
+    3. Manually re-classify components by number based on user observations.
+
     Unlike other decision node functions, ifTrue and ifFalse are not inputs
     since the same classification is assigned to all components listed in
     decide_comps
@@ -550,6 +552,9 @@ def calc_kappa_rho_elbows_kundu(
     based on the method by Kundu in the MEICA v2.7 code. Another elbow calculation would
     require a distinct function. Ideally, there can be one elbow function can allows for
     some more flexible options
+
+    This also uses all unclassified components as part of the elbow calculation, irregardless
+    of what is in decide_comps.
     """
 
     # If kappa_only or rho_only is true kappa or rho might not actually be
@@ -568,8 +573,6 @@ def calc_kappa_rho_elbows_kundu(
         "varex_upper_p": None,
         "kappa_elbow_kundu": None,
         "rho_elbow_kundu": None,
-        "kappa_only": kappa_only,
-        "rho_only": rho_only,
     }
 
     if only_used_metrics:

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -207,13 +207,16 @@ def manual_classify(
         outputs["numFalse"] = 0
     else:
         decision_boolean = pd.Series(True, index=comps2use)
-        selector = change_comptable_classifications(
+        (
+            selector,
+            outputs["numTrue"],
+            outputs["numFalse"],
+        ) = change_comptable_classifications(
             selector, ifTrue, ifFalse, decision_boolean, tag_ifTrue=tag
         )
-        outputs["numTrue"] = decision_boolean.sum()
-        outputs["numFalse"] = np.logical_not(decision_boolean).sum()
-        # print(('numTrue={}, numFalse={}, numcomps2use={}'.format(
-        #    numTrue, numFalse, len(comps2use))))
+        # outputs["numTrue"] = decision_boolean.sum()
+        # outputs["numFalse"] = np.logical_not(decision_boolean).sum()
+
         log_decision_tree_step(
             function_name_idx,
             comps2use,
@@ -368,7 +371,11 @@ def dec_left_op_right(
             val2 = right  # should be a fixed number
         decision_boolean = eval(f"(left_scale*val1) {op} (right_scale * val2)")
 
-        selector = change_comptable_classifications(
+        (
+            selector,
+            outputs["numTrue"],
+            outputs["numFalse"],
+        ) = change_comptable_classifications(
             selector,
             ifTrue,
             ifFalse,
@@ -376,10 +383,9 @@ def dec_left_op_right(
             tag_ifTrue=tag_ifTrue,
             tag_ifFalse=tag_ifFalse,
         )
-        outputs["numTrue"] = np.asarray(decision_boolean).sum()
-        outputs["numFalse"] = np.logical_not(decision_boolean).sum()
-        # print(('numTrue={}, numFalse={}, numcomps2use={}'.format(
-        #    numTrue, numFalse, len(comps2use))))
+        # outputs["numTrue"] = np.asarray(decision_boolean).sum()
+        # outputs["numFalse"] = np.logical_not(decision_boolean).sum()
+
         log_decision_tree_step(
             function_name_idx,
             comps2use,
@@ -489,7 +495,11 @@ def dec_variance_lessthan_thresholds(
             while variance[decision_boolean].sum() > all_comp_threshold:
                 cutcomp = variance[decision_boolean].idxmax
                 decision_boolean[cutcomp] = False
-        selector = change_comptable_classifications(
+        (
+            selector,
+            outputs["numTrue"],
+            outputs["numFalse"],
+        ) = change_comptable_classifications(
             selector,
             ifTrue,
             ifFalse,
@@ -497,10 +507,9 @@ def dec_variance_lessthan_thresholds(
             tag_ifTrue=tag_ifTrue,
             tag_ifFalse=tag_ifFalse,
         )
-        outputs["numTrue"] = np.asarray(decision_boolean).sum()
-        outputs["numFalse"] = np.logical_not(decision_boolean).sum()
-        # print(('numTrue={}, numFalse={}, numcomps2use={}'.format(
-        #    numTrue, numFalse, len(comps2use))))
+        # outputs["numTrue"] = np.asarray(decision_boolean).sum()
+        # outputs["numFalse"] = np.logical_not(decision_boolean).sum()
+
         log_decision_tree_step(
             function_name_idx,
             comps2use,

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -155,11 +155,12 @@ def manual_classify(
     selector,
     decide_comps,
     new_classification,
-    clear_rationale=False,
+    clear_classification_tags=False,
     log_extra_report="",
     log_extra_info="",
     custom_node_label="",
     only_used_metrics=False,
+    tag=None,
 ):
     """
     Explicitly assign a classifictation, defined in iffrue,
@@ -184,8 +185,8 @@ def manual_classify(
         in new_classification. Options are 'unclassified', 'accepted',
         'rejected', or intermediate_classification labels predefined in the
         decision tree
-    clear_rationale: :obj: `bool`
-        If True, reset all values in the 'rationale' column to empty strings
+    clear_classification_tags: :obj: `bool`
+        If True, reset all values in the 'classification_tags' column to empty strings
         If False, do nothing
     {log_extra}
     {custom_node_label}
@@ -237,7 +238,7 @@ def manual_classify(
     else:
         decision_boolean = pd.Series(True, index=comps2use)
         selector = change_comptable_classifications(
-            selector, ifTrue, ifFalse, decision_boolean
+            selector, ifTrue, ifFalse, decision_boolean, tag_ifTrue=tag
         )
         outputs["numTrue"] = decision_boolean.sum()
         outputs["numFalse"] = np.logical_not(decision_boolean).sum()
@@ -252,12 +253,9 @@ def manual_classify(
             ifFalse=ifFalse,
         )
 
-    if clear_rationale:
-        component_table["rationale"] = ""
-        LGR.info(
-            function_name_idx
-            + " component classification 'rationale' values are set to empty strings"
-        )
+    if clear_classification_tags:
+        component_table["classification_tags"] = ""
+        LGR.info(function_name_idx + " component classification tags are cleared")
 
     selector.nodes[selector.current_node_idx]["outputs"] = outputs
 
@@ -281,6 +279,8 @@ def dec_left_op_right(
     log_extra_info="",
     custom_node_label="",
     only_used_metrics=False,
+    tag_ifTrue=None,
+    tag_ifFalse=None,
 ):
     """
     Tests a relationship between (left_scale*)left and (right_scale*right)
@@ -401,7 +401,12 @@ def dec_left_op_right(
         decision_boolean = eval(f"(left_scale*val1) {op} (right_scale * val2)")
 
         selector = change_comptable_classifications(
-            selector, ifTrue, ifFalse, decision_boolean
+            selector,
+            ifTrue,
+            ifFalse,
+            decision_boolean,
+            tag_ifTrue=tag_ifTrue,
+            tag_ifFalse=tag_ifFalse,
         )
         outputs["numTrue"] = np.asarray(decision_boolean).sum()
         outputs["numFalse"] = np.logical_not(decision_boolean).sum()
@@ -436,6 +441,8 @@ def dec_variance_lessthan_thresholds(
     log_extra_info="",
     custom_node_label="",
     only_used_metrics=False,
+    tag_ifTrue=None,
+    tag_ifFalse=None,
 ):
     """
     Finds components with variance<single_comp_threshold.
@@ -515,7 +522,12 @@ def dec_variance_lessthan_thresholds(
                 cutcomp = variance[decision_boolean].idxmax
                 decision_boolean[cutcomp] = False
         selector = change_comptable_classifications(
-            selector, ifTrue, ifFalse, decision_boolean
+            selector,
+            ifTrue,
+            ifFalse,
+            decision_boolean,
+            tag_ifTrue=tag_ifTrue,
+            tag_ifFalse=tag_ifFalse,
         )
         outputs["numTrue"] = np.asarray(decision_boolean).sum()
         outputs["numFalse"] = np.logical_not(decision_boolean).sum()
@@ -720,6 +732,10 @@ def calc_kappa_rho_elbows_kundu(
 calc_kappa_rho_elbows_kundu.__doc__ = calc_kappa_rho_elbows_kundu.__doc__.format(
     **decision_docs
 )
+
+"""
+EVERTYHING BELOW HERE IS FOR THE KUNDU DECISION TREE AND IS NOT YET UPDATED
+"""
 
 
 def classification_exists(

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -118,6 +118,7 @@ def manual_classify(
     custom_node_label="",
     only_used_metrics=False,
     tag=None,
+    dont_warn_reclassify=False,
 ):
     """
     Explicitly assign a classifictation, defined in new_classification,
@@ -141,6 +142,12 @@ def manual_classify(
         A classification tag to assign to all components being reclassified.
         This should be one of the tags defined by classification_tags in
         the decision tree specification
+    dont_warn_reclassify: :obj:`bool`
+        By default, if this function changes a component classification from accepted or
+        rejected to something else, it gives a warning, since those should be terminal
+        classifications. If this is True, that warning is suppressed.
+        (Useful if manual_classify is used to reset all labels to unclassified).
+        default=False
     {log_extra}
     {custom_node_label}
     {only_used_metrics}

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -337,14 +337,19 @@ def dec_left_op_right(
             outputs["used_cross_component_metrics"].update([left])
             left = selector.cross_component_metrics[left]
         else:
-            raise ValueError(f"{left} is neither a metric in component_table nor selector.cross_component_metrics")
+            raise ValueError(
+                f"{left} is neither a metric in component_table nor selector.cross_component_metrics"
+            )
     if isinstance(right, str):
-        outputs["used_metrics"].update([right])
+        if right in selector.component_table.columns:
+            outputs["used_metrics"].update([right])
         elif right in selector.cross_component_metrics:
             outputs["used_cross_component_metrics"].update([right])
             right = selector.cross_component_metrics[right]
         else:
-            raise ValueError(f"{left} is neither a metric in component_table nor selector.cross_component_metrics")
+            raise ValueError(
+                f"{right} is neither a metric in component_table nor selector.cross_component_metrics"
+            )
 
     if only_used_metrics:
         return outputs["used_metrics"]
@@ -588,6 +593,11 @@ def calc_kappa_rho_elbows_kundu(
     outputs = {
         "decision_node_idx": selector.current_node_idx,
         "used_metrics": set(["kappa", "rho"]),
+        "calc_cross_comp_metrics": [
+            "kappa_elbow_kundu",
+            "rho_elbow_kundu",
+            "varex_upper_p",
+        ],
         "node_label": None,
         "n_echos": n_echos,
         "varex_upper_p": None,
@@ -689,7 +699,7 @@ def calc_kappa_rho_elbows_kundu(
         #         getelbow(comptable["kappa"], return_val=True),
         #     )
         # )
-        outputs["rho_elbow"] = np.mean(
+        outputs["rho_elbow_kundu"] = np.mean(
             (
                 getelbow(component_table.loc[ncls, "rho"], return_val=True),
                 getelbow(component_table["rho"], return_val=True),
@@ -700,7 +710,7 @@ def calc_kappa_rho_elbows_kundu(
 
         # print(('numTrue={}, numFalse={}, numcomps2use={}'.format(
         #        numTrue, numFalse, len(comps2use))))
-        log_decision_tree_step(function_name_idx, comps2use)
+        log_decision_tree_step(function_name_idx, comps2use, calc_outputs=outputs)
 
     selector.nodes[selector.current_node_idx]["outputs"] = outputs
 

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -237,8 +237,8 @@ def manual_classify(
         outputs["numFalse"] = 0
     else:
         decision_boolean = pd.Series(True, index=comps2use)
-        component_table = change_comptable_classifications(
-            component_table, ifTrue, ifFalse, decision_boolean, str(decision_node_idx)
+        DT_class = change_comptable_classifications(
+            DT_class, ifTrue, ifFalse, decision_boolean, decision_node_idx
         )
         outputs["numTrue"] = decision_boolean.sum()
         outputs["numFalse"] = np.logical_not(decision_boolean).sum()
@@ -384,8 +384,8 @@ def left_op_right(
             val2 = right  # should be a fixed number
         decision_boolean = eval(f"(left_scale*val1) {op} (right_scale * val2)")
 
-        comptable = change_comptable_classifications(
-            component_table, ifTrue, ifFalse, decision_boolean, str(decision_node_idx)
+        DT_class = change_comptable_classifications(
+            DT_class, ifTrue, ifFalse, decision_boolean, decision_node_idx
         )
         outputs["numTrue"] = np.asarray(decision_boolean).sum()
         outputs["numFalse"] = np.logical_not(decision_boolean).sum()
@@ -739,8 +739,8 @@ def variance_lessthan_thresholds(
             while variance[decision_boolean].sum() > all_comp_threshold:
                 cutcomp = variance[decision_boolean].idxmax
                 decision_boolean[cutcomp] = False
-        component_table = change_comptable_classifications(
-            component_table, ifTrue, ifFalse, decision_boolean, str(decision_node_idx)
+        DT_class = change_comptable_classifications(
+            DT_class, ifTrue, ifFalse, decision_boolean, decision_node_idx
         )
         outputs["numTrue"] = np.asarray(decision_boolean).sum()
         outputs["numFalse"] = np.logical_not(decision_boolean).sum()
@@ -931,8 +931,8 @@ def kappa_rho_elbow_cutoffs_kundu(
                 component_table.loc[comps2use, "kappa"] >= outputs["kappa_elbow"]
             ) & (component_table.loc[comps2use, "rho"] < outputs["rho_elbow"])
 
-        component_table = change_comptable_classifications(
-            component_table, ifTrue, ifFalse, decision_boolean, str(decision_node_idx)
+        DT_class = change_comptable_classifications(
+            DT_class, ifTrue, ifFalse, decision_boolean, decision_node_idx
         )
         outputs["numTrue"] = np.asarray(decision_boolean).sum()
         outputs["numFalse"] = np.logical_not(decision_boolean).sum()

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -261,7 +261,6 @@ def manual_classify(
         )
 
     dnode_outputs = {"outputs": outputs}
-    DT_class.component_table = component_table
 
     return DT_class, dnode_outputs
 
@@ -402,7 +401,7 @@ def left_op_right(
         )
 
     dnode_outputs = {"outputs": outputs}
-    DT_class.component_table = component_table
+
     return DT_class, dnode_outputs
 
 
@@ -757,7 +756,6 @@ def variance_lessthan_thresholds(
         )
 
     dnode_outputs = {"outputs": outputs}
-    DT_class.component_table = component_table
     return DT_class, dnode_outputs
 
 
@@ -950,7 +948,7 @@ def kappa_rho_elbow_cutoffs_kundu(
         )
 
     dnode_outputs = {"outputs": outputs}
-    DT_class.component_table = component_table
+
     return DT_class, dnode_outputs
 
 

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -15,39 +15,36 @@ from tedana.selection._utils import (
     log_decision_tree_step,
     change_comptable_classifications,
     getelbow,
-    create_dnode_outputs,
     get_extend_factor,
     kappa_elbow_kundu,
     get_new_meanmetricrank,
     prev_classified_comps,
 )
 
-
-# clean_dataframe, new_decision_node_info,
 LGR = logging.getLogger("GENERAL")
 RepLGR = logging.getLogger("REPORT")
 RefLGR = logging.getLogger("REFERENCES")
 
 decision_docs = {
     "selector": """\
-    selector: :obj:`tedana.selection.ComponentSelector`
-        This structure contains most of the information needed to execute each
-        decision node function and to store the ouput of the function. The class
-        description has full details. Key elements include: component_table:
-        The metrics for each component, and the classification
-        labels and tags; cross_component_metrics: Values like the kappa and rho
-        elbows that are used to create decision criteria; nodes: Information on
-        the function calls for each step in the decision tree; and
-        current_node_idx: which is the ordered index for when a function is
-        called in the decision tree\
+selector: :obj:`tedana.selection.ComponentSelector`
+    This structure contains most of the information needed to execute each
+    decision node function and to store the ouput of the function. The class
+    description has full details. Key elements include: component_table:
+    The metrics for each component, and the classification
+    labels and tags; cross_component_metrics: Values like the kappa and rho
+    elbows that are used to create decision criteria; nodes: Information on
+    the function calls for each step in the decision tree; and
+    current_node_idx: which is the ordered index for when a function is
+    called in the decision tree\
 """,
     "ifTrueFalse": """\
 ifTrue, ifFalse: :obj:`str`
     If the condition in this step is true or false, give the component
     the label in this string. Options are 'accepted', 'rejected',
     'nochange', or intermediate_classification labels predefined in the
-    decision tree
-    If 'nochange' then don't change the current component classification\
+    decision tree. If 'nochange' then don't change the current component
+    classification\
 """,
     "decide_comps": """\
 decide_comps: :obj:`str` or :obj:`list[str]`
@@ -466,7 +463,7 @@ def dec_variance_lessthan_thresholds(
         RepLGR.info(log_extra_report)
 
     comps2use, component_table = selectcomps2use(selector, decide_comps)
-    metrics_exist, missing_metrics = confirm_metrics_exist(
+    confirm_metrics_exist(
         component_table, outputs["used_metrics"], function_name=function_name_idx
     )
 
@@ -615,7 +612,7 @@ def calc_kappa_rho_elbows_kundu(
         RepLGR.info(log_extra_report)
 
     comps2use, component_table = selectcomps2use(selector, decide_comps)
-    metrics_exist, missing_metrics = confirm_metrics_exist(
+    confirm_metrics_exist(
         component_table, outputs["used_metrics"], function_name=function_name_idx
     )
 

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -152,7 +152,7 @@ rho_elbow: :obj:`float`
 
 
 def manual_classify(
-    DT_class,
+    selector,
     decision_node_idx,
     decide_comps,
     new_classification,
@@ -229,7 +229,7 @@ def manual_classify(
     if log_extra_report:
         RepLGR.info(log_extra_report)
 
-    comps2use, component_table = selectcomps2use(DT_class, decide_comps)
+    comps2use, component_table = selectcomps2use(selector, decide_comps)
 
     if comps2use is None:
         log_decision_tree_step(function_name_idx, comps2use, decide_comps=decide_comps)
@@ -237,8 +237,8 @@ def manual_classify(
         outputs["numFalse"] = 0
     else:
         decision_boolean = pd.Series(True, index=comps2use)
-        DT_class = change_comptable_classifications(
-            DT_class, ifTrue, ifFalse, decision_boolean, decision_node_idx
+        selector = change_comptable_classifications(
+            selector, ifTrue, ifFalse, decision_boolean, decision_node_idx
         )
         outputs["numTrue"] = decision_boolean.sum()
         outputs["numFalse"] = np.logical_not(decision_boolean).sum()
@@ -262,14 +262,14 @@ def manual_classify(
 
     dnode_outputs = {"outputs": outputs}
 
-    return DT_class, dnode_outputs
+    return selector, dnode_outputs
 
 
 manual_classify.__doc__ = manual_classify.__doc__.format(**decision_docs)
 
 
 def left_op_right(
-    DT_class,
+    selector,
     decision_node_idx,
     ifTrue,
     ifFalse,
@@ -363,7 +363,7 @@ def left_op_right(
     if log_extra_report:
         RepLGR.info(log_extra_report)
 
-    comps2use, component_table = selectcomps2use(DT_class, decide_comps)
+    comps2use, component_table = selectcomps2use(selector, decide_comps)
 
     confirm_metrics_exist(
         component_table, outputs["used_metrics"], function_name=function_name_idx
@@ -384,8 +384,8 @@ def left_op_right(
             val2 = right  # should be a fixed number
         decision_boolean = eval(f"(left_scale*val1) {op} (right_scale * val2)")
 
-        DT_class = change_comptable_classifications(
-            DT_class, ifTrue, ifFalse, decision_boolean, decision_node_idx
+        selector = change_comptable_classifications(
+            selector, ifTrue, ifFalse, decision_boolean, decision_node_idx
         )
         outputs["numTrue"] = np.asarray(decision_boolean).sum()
         outputs["numFalse"] = np.logical_not(decision_boolean).sum()
@@ -402,14 +402,14 @@ def left_op_right(
 
     dnode_outputs = {"outputs": outputs}
 
-    return DT_class, dnode_outputs
+    return selector, dnode_outputs
 
 
 left_op_right.__doc__ = left_op_right.__doc__.format(**decision_docs)
 
 
 def variance_lessthan_thresholds(
-    DT_class,
+    selector,
     decision_node_idx,
     ifTrue,
     ifFalse,
@@ -477,7 +477,7 @@ def variance_lessthan_thresholds(
     if log_extra_report:
         RepLGR.info(log_extra_report)
 
-    comps2use, component_table = selectcomps2use(DT_class, decide_comps)
+    comps2use, component_table = selectcomps2use(selector, decide_comps)
     metrics_exist, missing_metrics = confirm_metrics_exist(
         component_table, outputs["used_metrics"], function_name=function_name_idx
     )
@@ -497,8 +497,8 @@ def variance_lessthan_thresholds(
             while variance[decision_boolean].sum() > all_comp_threshold:
                 cutcomp = variance[decision_boolean].idxmax
                 decision_boolean[cutcomp] = False
-        DT_class = change_comptable_classifications(
-            DT_class, ifTrue, ifFalse, decision_boolean, decision_node_idx
+        selector = change_comptable_classifications(
+            selector, ifTrue, ifFalse, decision_boolean, decision_node_idx
         )
         outputs["numTrue"] = np.asarray(decision_boolean).sum()
         outputs["numFalse"] = np.logical_not(decision_boolean).sum()
@@ -514,7 +514,7 @@ def variance_lessthan_thresholds(
         )
 
     dnode_outputs = {"outputs": outputs}
-    return DT_class, dnode_outputs
+    return selector, dnode_outputs
 
 
 variance_lessthan_thresholds.__doc__ = variance_lessthan_thresholds.__doc__.format(
@@ -523,7 +523,7 @@ variance_lessthan_thresholds.__doc__ = variance_lessthan_thresholds.__doc__.form
 
 
 def kappa_rho_elbow_cutoffs_kundu(
-    DT_class,
+    selector,
     decision_node_idx,
     ifTrue,
     ifFalse,
@@ -617,12 +617,12 @@ def kappa_rho_elbow_cutoffs_kundu(
     if log_extra_report:
         RepLGR.info(log_extra_report)
 
-    comps2use, component_table = selectcomps2use(DT_class, decide_comps)
+    comps2use, component_table = selectcomps2use(selector, decide_comps)
     metrics_exist, missing_metrics = confirm_metrics_exist(
         component_table, outputs["used_metrics"], function_name=function_name_idx
     )
 
-    unclassified_comps2use = selectcomps2use(DT_class, "unclassified")[0]
+    unclassified_comps2use = selectcomps2use(selector, "unclassified")[0]
 
     if (comps2use is None) or (unclassified_comps2use is None):
         if comps2use is None:
@@ -689,8 +689,8 @@ def kappa_rho_elbow_cutoffs_kundu(
                 component_table.loc[comps2use, "kappa"] >= outputs["kappa_elbow"]
             ) & (component_table.loc[comps2use, "rho"] < outputs["rho_elbow"])
 
-        DT_class = change_comptable_classifications(
-            DT_class, ifTrue, ifFalse, decision_boolean, decision_node_idx
+        selector = change_comptable_classifications(
+            selector, ifTrue, ifFalse, decision_boolean, decision_node_idx
         )
         outputs["numTrue"] = np.asarray(decision_boolean).sum()
         outputs["numFalse"] = np.logical_not(decision_boolean).sum()
@@ -707,7 +707,7 @@ def kappa_rho_elbow_cutoffs_kundu(
 
     dnode_outputs = {"outputs": outputs}
 
-    return DT_class, dnode_outputs
+    return selector, dnode_outputs
 
 
 kappa_rho_elbow_cutoffs_kundu.__doc__ = kappa_rho_elbow_cutoffs_kundu.__doc__.format(

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -29,40 +29,33 @@ RepLGR = logging.getLogger("REPORT")
 RefLGR = logging.getLogger("REFERENCES")
 
 decision_docs = {
-    "comptable": """\
-comptable : (C x M) :obj:`pandas.DataFrame`
-    Component metric table. One row for each component, with a column for
-    each metric. The index should be the component number.\
+    "selector": """\
+    selector: :obj:`tedana.selection.ComponentSelector`
+        This structure contains most of the information needed to execute each
+        decision node function and to store the ouput of the function. The class
+        description has full details. Key elements include: component_table:
+        The metrics for each component, and the classification
+        labels and tags; cross_component_metrics: Values like the kappa and rho
+        elbows that are used to create decision criteria; nodes: Information on
+        the function calls for each step in the decision tree; and
+        current_node_idx: which is the ordered index for when a function is
+        called in the decision tree\
 """,
-    "decision_node_idx": """\
-decison_node_idx : :obj: `int`
-    The decision tree function are run as part of an ordered list.
-    This is the positional index for when this function has been run
-    as part of this list.\
-""",
-    "ifTrue": """\
-ifTrue : :obj:`str`
-    If the condition in this step is true, give the component
+    "ifTrueFalse": """\
+ifTrue, ifFalse: :obj:`str`
+    If the condition in this step is true or false, give the component
     the label in this string. Options are 'accepted', 'rejected',
     'nochange', or intermediate_classification labels predefined in the
     decision tree
     If 'nochange' then don't change the current component classification\
 """,
-    "ifFalse": """\
-ifFalse: :obj:`str`
-    If the condition in this step is false, give the component the label
-    in this string. Same options as ifTrue\
-""",
     "decide_comps": """\
-decide_comps: :obj:`str` or :obj:`list[str]` or :obj:`int` or :obj:`list[int]`
-    If this is string or a list of strings describing what classifications
-    of components to operate on, using the same labels as in ifTrue.
-    For example: decide_comps='unclassified' means to operate only on
-    unclassified components. The label 'all' will operate on all
-    components regardess of classification.
-    If this is an int or a list of int, operate on components with the
-    listed integer indices. For example: [0 1 5] will operate on 3 components
-    regardless of what their current classifications are.\
+decide_comps: :obj:`str` or :obj:`list[str]`
+    This is string or a list of strings describing what classifications
+    of components to operate on, using default or intermediate_classification
+    labels. For example: decide_comps='unclassified' means to operate only on
+    unclassified components. The label 'all' will operate on all components
+    regardess of classification.\
 """,
     "log_extra": """\
 log_extra_report, log_extra_info: :obj:`str`
@@ -84,43 +77,20 @@ tree summary table or flow chart. If custom_node_label is not empty, then the
 text in this parameter is used instead of the text would be automatically
 assigned within the function call default=""\
 """,
+    "tag_ifTrueFalse": """\
+tag_ifTrue, tag_ifFalse: :obj:`str`
+    A string containing a label in classification_tags that will be added to
+    the classification_tags column in component_table if a component is
+    classified as true or false. default=None
+""",
     "basicreturns": """\
-comptable: (C x M) :obj:`pandas.DataFrame`
-    Component metric table. One row for each component, with a column for
-    each metric. The index should be the component number.
-    Labels in the 'classifications' for components initially labeled in
-    decide_comps may change depending on the the ifTrue and ifFalse instructions.
-    When a classification changes, the 'rationale' column is appended to include
-    and additional decision node index and change. For example, if this function
-    is the 5th decision node run and a component is reclassified as 'accepted',
-    the string in 'rationale' is appended to include '5: accepted;'
-    comptable is only only returned if only_used_metrics=False
-dnode_outputs: :obj:`dict`
-    Several parameters that should be output from each decision node function
-    in a dictionary under the key 'outputs' When a function is run as output
-    as part of the decision tree class, this output will be added to the dictionary
-    with parameters that called the function with all the outputs under the 'outputs'
-    key. dnode_outputs includes the following fields\
-    used_metrics: :obj: `list[str]`
-        A list of all metrics from the comptable header used within this function.
-        Note, this must be a list even if only one metric is used
-    node_label: :obj: `str`
-        A brief label for what happens in this node that can be used in a decision
-    tree summary table or flow chart. This is defined in the function unless
-    custom_node_label is not empty. In that case, node_label=custom_node_label
-    numTrue, numFalse: :obj: `int`
-        The number of components that were classified as true or false respectively
-    in this decision tree step.\
-""",
-    "n_echos": """\
-n_echos: :obj:`int`
-    The number of echos in the multi-echo data
-        \
-""",
-    "n_vols": """\
-n_vols: :obj:`int`
-    The number of volumes (time points) in the fMRI data
-        \
+selector: :obj:`tedana.selection.ComponentSelector`
+    The key fields that will be changed in selector are the component
+    classifications and tags in component_table or a new metric that is
+    added to cross_component_metrics. The output field for the current
+    node will also be updated to include relevant information including
+    the use_metrics of the node, and the numTrue and numFalse components
+    the call to the node's function.\
 """,
     "extend_factor": """\
 extend_factor: :obj:`float`
@@ -138,16 +108,6 @@ prev_X_steps: :obj:`int`
     the decision tree
         \
         """,
-    "kappa_elbow": """\
-kappa_elbow: :obj:`float`
-    The kappa threshold below which components are less likely to contain T2* signal
-        \
-""",
-    "rho_elbow": """\
-rho_elbow: :obj:`float`
-    The rho threshold above which components are likely to contain nontrivial S0 signal
-        \
-""",
 }
 
 
@@ -163,22 +123,19 @@ def manual_classify(
     tag=None,
 ):
     """
-    Explicitly assign a classifictation, defined in iffrue,
-    to all the components in decide_comps. This was designed
-    with three use cases in mind:
-    1. Set the classifictions of all components to unclassified
-    for the first node of a decision tree.
-    clear_rationale=True is recommended for this use case
-    2. Shift all components between classifications, such as
-    provisionalaccept to accepted for the penultimate node in the
-    decision tree.
-    3. Manually re-classify components by number based on user
-    observations.
+    Explicitly assign a classifictation, defined in new_classification,
+    to all the components in decide_comps. This was designed with three use
+    cases in mind:
+    1. Set the classifications of all components to unclassified for the first
+    node of a decision tree. clear_classification_tags=True is recommended for
+    this use case
+    2. Shift all components between classifications, such as provisionalaccept
+    to accepted for the penultimate node in the decision tree.
+    3. Manually re-classify components by number based on user observations.
 
     Parameters
     ----------
-    {comptable}
-    {decision_node_idx}
+    {selector}
     {decide_comps}
     new_classification: :obj: `str`
         Assign all components identified in decide_comps the classification
@@ -186,11 +143,18 @@ def manual_classify(
         'rejected', or intermediate_classification labels predefined in the
         decision tree
     clear_classification_tags: :obj: `bool`
-        If True, reset all values in the 'classification_tags' column to empty strings
-        If False, do nothing
+        If True, reset all values in the 'classification_tags' column to empty
+        strings. This also can create the classification_tags column if it
+        does not already exist
+        If False, do nothing.
+    tag: :obj: `str`
+        A classification tag to assign to all components being reclassified.
+        This should be one of the tags defined by classification_tags in
+        the decision tree specification
     {log_extra}
     {custom_node_label}
     {only_used_metrics}
+
 
     Returns
     -------
@@ -291,12 +255,9 @@ def dec_left_op_right(
 
     Parameters
     ----------
-    {comptable}
-    {decision_node_idx}
-    {ifTrue}
-    {ifFalse}
+    {selector}
+    {ifTrueFalse}
     {decide_comps}
-
     op: :ojb:`str`
         Must be one of: ">", ">=", "==", "<=", "<"
         Applied the user defined operator to left op right
@@ -314,6 +275,7 @@ def dec_left_op_right(
     {log_extra}
     {custom_node_label}
     {only_used_metrics}
+    {tag_ifTrueFalse}
 
     Returns
     -------
@@ -452,23 +414,23 @@ def dec_variance_lessthan_thresholds(
 
     Parameters
     ----------
-    {comptable}
-    {decision_node_idx}
-    {ifTrue}
-    {ifFalse}
+    {selector}
+    {ifTrueFalse}
     {decide_comps}
     var_metric: :obj:`str`
         The name of the metric in comptable for variance. default=varexp
         This is an option so that it is possible to set this to normvarexp
         or some other variance measure
     single_comp_threshold: :obj:`float`
-        The threshold for which all components need to have lower variance
+        The threshold for which all components need to have lower variance.
+        default=0.1
     all_comp_threshold: :obj: `float`
         The threshold for which the sum of all components<single_comp_threshold
-        needs to be under
+        needs to be under. default=1.0
     {log_extra}
     {custom_node_label}
     {only_used_metrics}
+    {tag_ifTrueFalse}
 
     Returns
     -------
@@ -554,7 +516,6 @@ dec_variance_lessthan_thresholds.__doc__ = (
 def calc_kappa_rho_elbows_kundu(
     selector,
     decide_comps,
-    n_echos,
     log_extra_report="",
     log_extra_info="",
     custom_node_label="",
@@ -568,12 +529,8 @@ def calc_kappa_rho_elbows_kundu(
 
     Parameters
     ----------
-    {comptable}
-    {decision_node_idx}
-    {ifTrue}
-    {ifFalse}
+    {selector}
     {decide_comps}
-    {n_echos}
     {log_extra}
     {custom_node_label}
     {only_used_metrics}
@@ -586,10 +543,6 @@ def calc_kappa_rho_elbows_kundu(
     Returns
     -------
     {basicreturns}
-    dnode_ouputs also contains:
-    {n_echos}
-    {kappa_elbow}
-    {rho_elbow}
 
     Note
     ----
@@ -611,7 +564,7 @@ def calc_kappa_rho_elbows_kundu(
             "varex_upper_p",
         ],
         "node_label": None,
-        "n_echos": n_echos,
+        "n_echos": selector.n_echos,
         "varex_upper_p": None,
         "kappa_elbow_kundu": None,
         "rho_elbow_kundu": None,
@@ -675,7 +628,9 @@ def calc_kappa_rho_elbows_kundu(
                 function_name_idx, comps2use, decide_comps="unclassified"
             )
     else:
-        outputs["kappa_elbow_kundu"] = kappa_elbow_kundu(component_table, n_echos)
+        outputs["kappa_elbow_kundu"] = kappa_elbow_kundu(
+            component_table, selector.n_echos
+        )
         selector.cross_component_metrics["kappa_elbow_kundu"] = outputs[
             "kappa_elbow_kundu"
         ]
@@ -685,7 +640,7 @@ def calc_kappa_rho_elbows_kundu(
         # components
         # Upper limit for variance explained is median across components with high
         # Kappa values. High Kappa is defined as Kappa above Kappa elbow.
-        f05, _, f01 = getfbounds(n_echos)
+        f05, _, f01 = getfbounds(selector.n_echos)
         outputs["varex_upper_p"] = np.median(
             component_table.loc[
                 component_table["kappa"]
@@ -738,876 +693,876 @@ EVERTYHING BELOW HERE IS FOR THE KUNDU DECISION TREE AND IS NOT YET UPDATED
 """
 
 
-def classification_exists(
-    comptable,
-    decision_node_idx,
-    ifTrue,
-    ifFalse,
-    decide_comps,
-    class_comp_exists,
-    log_extra_report="",
-    log_extra_info="",
-    custom_node_label="",
-    only_used_metrics=False,
-):
-    """
-    If there are not compontents with a classification specified in class_comp_exists,
-    change the classification of all components in decide_comps
-    Parameters
-    ----------
-    {comptable}
-    {decision_node_idx}
-    {ifTrue}
-    {ifFalse}
-    {decide_comps}
-    class_comp_exists: :obj:`str` or :obj:`list[str]` or :obj:`int` or :obj:`list[int]`
-        This has the same structure options as decide_comps. This function tests
-        whether any components have the classifications defined in this variable.
-    {log_extra}
-    {custom_node_label}
-    {only_used_metrics}
-
-    Returns
-    -------
-    {basicreturns}
-
-    """
-
-    used_metrics = []
-    if only_used_metrics:
-        return used_metrics
-
-    function_name_idx = "Step {}: classification_exists".format(decision_node_idx)
-    if custom_node_label:
-        node_label = custom_node_label
-    else:
-        node_label = "Change {} if {} doesn't exist".format(
-            decide_comps, classification_exists
-        )
-
-    # Might want to add additional default logging to functions here
-    # The function input will be logged before the function call
-    if log_extra_info:
-        LGR.info(log_extra_info)
-    if log_extra_report:
-        RepLGR.info(log_extra_report)
-
-    comps2use = selectcomps2use(comptable, decide_comps)
-    do_comps_exist = selectcomps2use(comptable, class_comp_exists)
-
-    if comps2use is None:
-        log_decision_tree_step(function_name_idx, comps2use, decide_comps=decide_comps)
-        numTrue = 0
-        numFalse = 0
-    elif do_comps_exist is None:
-        # should be false for all components
-        decision_boolean = comptable.loc[comps2use, "component"] < -100
-        comptable = change_comptable_classifications(
-            comptable, ifTrue, ifFalse, decision_boolean, str(decision_node_idx)
-        )
-        numTrue = np.asarray(decision_boolean).sum()
-        # numtrue should always be 0 in this situation
-        numFalse = np.logical_not(decision_boolean).sum()
-        # print(('numTrue={}, numFalse={}, numcomps2use={}'.format(
-        #    numTrue, numFalse, len(comps2use))))
-        log_decision_tree_step(
-            function_name_idx,
-            comps2use,
-            numTrue=numTrue,
-            numFalse=numFalse,
-            ifTrue=ifTrue,
-            ifFalse=ifFalse,
-        )
-    else:
-        numTrue = len(comps2use)
-        numFalse = 0
-        log_decision_tree_step(
-            function_name_idx,
-            comps2use,
-            numTrue=numTrue,
-            numFalse=numFalse,
-            ifTrue=ifTrue,
-            ifFalse=ifFalse,
-        )
-
-    dnode_outputs = create_dnode_outputs(
-        decision_node_idx, used_metrics, node_label, numTrue, numFalse
-    )
-
-    return comptable, dnode_outputs
-
-
-def meanmetricrank_and_variance_greaterthan_thresh(
-    comptable,
-    decision_node_idx,
-    ifTrue,
-    ifFalse,
-    decide_comps,
-    n_vols,
-    high_perc=90,
-    extend_factor=None,
-    log_extra_report="",
-    log_extra_info="",
-    custom_node_label="",
-    only_used_metrics=False,
-):
-    """
-    The 'mean metric rank' (formerly d_table) is the mean of rankings of 5 metrics:
-        'kappa', 'dice_FT2', 'signal-noise_t',
-        and 'countnoise', 'countsigFT2'
-    For these 5 metrics, a lower rank (smaller number) is less likely to be
-    T2* weighted.
-    This function tests of meanmetricrank is above a threshold based on the number
-    of provisionally accepted components & variance based on a threshold related
-    to the variance of provisionally accepted components. This is indented to
-    reject components that are greater than both of these thresholds
-
-    Parameters
-    ----------
-    {comptable}
-    {decision_node_idx}
-    {ifTrue}
-    {ifFalse}
-    {decide_comps}
-    {n_vols}
-    high_perc: :obj:`int`
-        A percentile threshold to apply to components to set the variance
-        threshold. default=90
-    {extend_factor}
-    {log_extra}
-    {custom_node_label}
-    {only_used_metrics}
-
-    Returns
-    -------
-    {basicreturns}
-    dnode_ouputs also contains:
-    num_prov_accept: :obj:`int`
-        Number of provisionally accepted components
-    max_good_meanmetricrank: :obj:`float`
-        The threshold used meanmetricrank
-    varex_threshold: :obj:`float`
-        The threshold used for variance
-    """
-
-    used_metrics = ["d_table_score", "variance explained"]
-    if only_used_metrics:
-        return used_metrics
-
-    function_name_idx = (
-        "Step {}: meanmetricrank_and_variance_greaterthan_thresh".format(
-            decision_node_idx
-        )
-    )
-    if custom_node_label:
-        node_label = custom_node_label
-    else:
-        node_label = "MeanRank & Variance Thresholding"
-
-    if log_extra_info:
-        LGR.info(log_extra_info)
-    if log_extra_report:
-        RepLGR.info(log_extra_report)
-
-    metrics_exist, missing_metrics = confirm_metrics_exist(
-        comptable, used_metrics, function_name=function_name_idx
-    )
-
-    comps2use = selectcomps2use(comptable, decide_comps)
-    provaccept_comps2use = selectcomps2use(comptable, ["provisionalaccept"])
-    if (comps2use is None) or (provaccept_comps2use is None):
-        if comps2use is None:
-            log_decision_tree_step(
-                function_name_idx, comps2use, decide_comps=decide_comps
-            )
-        if provaccept_comps2use is None:
-            log_decision_tree_step(
-                function_name_idx, comps2use, decide_comps="provisionalaccept"
-            )
-        dnode_outputs = create_dnode_outputs(
-            decision_node_idx, used_metrics, node_label, 0, 0
-        )
-    else:
-        num_prov_accept = len(provaccept_comps2use)
-        varex_upper_thresh = scoreatpercentile(
-            comptable.loc[provaccept_comps2use, "variance explained"], high_perc
-        )
-
-        extend_factor = get_extend_factor(n_vols=n_vols, extend_factor=extend_factor)
-        max_good_meanmetricrank = extend_factor * num_prov_accept
-
-        decision_boolean1 = (
-            comptable.loc[comps2use, "d_table_score"] > max_good_meanmetricrank
-        )
-        decision_boolean2 = (
-            comptable.loc[comps2use, "variance explained"] > varex_upper_thresh
-        )
-        decision_boolean = decision_boolean1 & decision_boolean2
-
-        comptable = change_comptable_classifications(
-            comptable, ifTrue, ifFalse, decision_boolean, str(decision_node_idx)
-        )
-        numTrue = np.asarray(decision_boolean).sum()
-        numFalse = np.logical_not(decision_boolean).sum()
-        # print(('numTrue={}, numFalse={}, numcomps2use={}'.format(
-        #    numTrue, numFalse, len(comps2use))))
-        log_decision_tree_step(
-            function_name_idx,
-            comps2use,
-            numTrue=numTrue,
-            numFalse=numFalse,
-            ifTrue=ifTrue,
-            ifFalse=ifFalse,
-        )
-
-        dnode_outputs = create_dnode_outputs(
-            decision_node_idx,
-            used_metrics,
-            node_label,
-            numTrue,
-            numFalse,
-            num_prov_accept=num_prov_accept,
-            varex_threshold=varex_upper_thresh,
-            max_good_meanmetricrank=max_good_meanmetricrank,
-            extend_factor=extend_factor,
-        )
-
-    return comptable, dnode_outputs
-
-
-meanmetricrank_and_variance_greaterthan_thresh.__doc__ = (
-    meanmetricrank_and_variance_greaterthan_thresh.__doc__.format(**decision_docs)
-)
-
-
-def lowvariance_highmeanmetricrank_lowkappa(
-    comptable,
-    decision_node_idx,
-    ifTrue,
-    ifFalse,
-    decide_comps,
-    n_echos,
-    n_vols,
-    low_perc=25,
-    extend_factor=None,
-    log_extra_report="",
-    log_extra_info="",
-    custom_node_label="",
-    only_used_metrics=False,
-):
-    """
-    Finds components with variance below a threshold,
-    a mean metric rank above a threshold, and kappa below a threshold.
-    This would typically be used to identify remaining components that would
-    otherwise be rejected & put them in accept with a 'low variance' tag
-
-    Parameters
-    ----------
-    {comptable}
-    {decision_node_idx}
-    {ifTrue}
-    {ifFalse}
-    {decide_comps}
-    {n_echos}
-    {n_vols}
-    {extend_factor}
-    {log_extra}
-    {custom_node_label}
-    {only_used_metrics}
-
-    Returns
-    -------
-    {basicreturns}
-    """
-
-    used_metrics = ["variance explained", "kappa", "d_table_score"]
-    if only_used_metrics:
-        return used_metrics
-
-    function_name_idx = "Step {}: lowvariance_highmeanmetricrank_lowkappa".format(
-        decision_node_idx
-    )
-    if custom_node_label:
-        node_label = custom_node_label
-    else:
-        node_label = "lowvar highmeanmetricrank lowkappa"
-
-    if log_extra_info:
-        LGR.info(log_extra_info)
-    if log_extra_report:
-        RepLGR.info(log_extra_report)
-    metrics_exist, missing_metrics = confirm_metrics_exist(
-        comptable, used_metrics, function_name=function_name_idx
-    )
-
-    comps2use = selectcomps2use(comptable, decide_comps)
-    provaccept_comps2use = selectcomps2use(comptable, ["provisionalaccept"])
-
-    if (comps2use is None) or (provaccept_comps2use is None):
-        if comps2use is None:
-            log_decision_tree_step(
-                function_name_idx, comps2use, decide_comps=decide_comps
-            )
-        if provaccept_comps2use is None:
-            log_decision_tree_step(
-                function_name_idx, comps2use, decide_comps="provisionalaccept"
-            )
-        dnode_outputs = create_dnode_outputs(
-            decision_node_idx, used_metrics, node_label, 0, 0
-        )
-    else:
-        # low variance threshold
-        varex_lower_thresh = scoreatpercentile(
-            comptable.loc[provaccept_comps2use, "variance explained"], low_perc
-        )
-        db_low_varex = (
-            comptable.loc[comps2use, "variance explained"] < varex_lower_thresh
-        )
-
-        # mean metric rank threshold
-        num_prov_accept = len(provaccept_comps2use)
-        extend_factor = get_extend_factor(n_vols=n_vols, extend_factor=extend_factor)
-        max_good_meanmetricrank = extend_factor * num_prov_accept
-        db_meanmetricrank = (
-            comptable.loc[comps2use, "d_table_score"] < max_good_meanmetricrank
-        )
-
-        # kappa threshold
-        kappa_elbow = kappa_elbow_kundu(comptable, n_echos)
-        db_kappa = comptable.loc[comps2use, "kappa"] > kappa_elbow
-
-        # combine the 3 thresholds
-        decision_boolean = db_low_varex & db_meanmetricrank & db_kappa
-
-        comptable = change_comptable_classifications(
-            comptable, ifTrue, ifFalse, decision_boolean, str(decision_node_idx)
-        )
-        numTrue = np.asarray(decision_boolean).sum()
-        numFalse = np.logical_not(decision_boolean).sum()
-        # print(('numTrue={}, numFalse={}, numcomps2use={}'.format(
-        #    numTrue, numFalse, len(comps2use))))
-
-        log_decision_tree_step(
-            function_name_idx,
-            comps2use,
-            numTrue=numTrue,
-            numFalse=numFalse,
-            ifTrue=ifTrue,
-            ifFalse=ifFalse,
-        )
-
-        dnode_outputs = create_dnode_outputs(
-            decision_node_idx,
-            used_metrics,
-            node_label,
-            numTrue,
-            numFalse,
-            n_echos=n_echos,
-            n_vols=n_vols,
-            kappa_elbow=kappa_elbow,
-            varex_threshold=varex_lower_thresh,
-            max_good_meanmetricrank=max_good_meanmetricrank,
-            num_prov_accept=num_prov_accept,
-            extend_factor=extend_factor,
-        )
-
-    return comptable, dnode_outputs
-
-
-lowvariance_highmeanmetricrank_lowkappa.__doc__ = (
-    lowvariance_highmeanmetricrank_lowkappa.__doc__.format(**decision_docs)
-)
-
-
-def highvariance_highmeanmetricrank_highkapparatio(
-    comptable,
-    decision_node_idx,
-    ifTrue,
-    ifFalse,
-    decide_comps,
-    n_echos,
-    n_vols=None,
-    extend_factor=None,
-    restrict_factor=2,
-    prev_X_steps=0,
-    high_perc=90,
-    log_extra_report="",
-    log_extra_info="",
-    custom_node_label="",
-    only_used_metrics=False,
-):
-    """
-    Finds components with variance above a threshold,
-    a mean metric rank above a threshold, and kappa ratio above a threshold.
-    This would typically be used to identify borderline remaining components to reject.
-
-    Parameters
-    ----------
-    {comptable}
-    {decision_node_idx}
-    {ifTrue}
-    {ifFalse}
-    {decide_comps}
-    {n_echos}
-    {n_vols}
-    {extend_factor}
-    {restrict_factor}
-    {prev_X_steps}
-    {log_extra}
-    {custom_node_label}
-    {only_used_metrics}
-
-    Returns
-    -------
-    {basicreturns}
-    """
-
-    used_metrics = [
-        "variance explained",
-        "kappa",
-        "rho",
-        "dice_FT2",
-        "signal-noise_t",
-        "countsigFT2",
-        "countnoise",
-    ]
-    if only_used_metrics:
-        return used_metrics
-
-    function_name_idx = (
-        "Step {}: highvariance_highmeanmetricrank_highkapparatio".format(
-            decision_node_idx
-        )
-    )
-    if custom_node_label:
-        node_label = custom_node_label
-    else:
-        node_label = "highvar highmeanmetricrank highkapparatio"
-
-    if log_extra_info:
-        LGR.info(log_extra_info)
-    if log_extra_report:
-        RepLGR.info(log_extra_report)
-    metrics_exist, missing_metrics = confirm_metrics_exist(
-        comptable, used_metrics, function_name=function_name_idx
-    )
-
-    comps2use = selectcomps2use(comptable, decide_comps)
-    if comps2use is None:
-        log_decision_tree_step(function_name_idx, comps2use, decide_comps=decide_comps)
-        numTrue = 0
-        numFalse = 0
-        dnode_outputs = create_dnode_outputs(
-            decision_node_idx, used_metrics, node_label, 0, 0
-        )
-    else:
-        # This will either identify a previously calculated revised meanmetricrank and
-        # return it or it will calculate a revised meanmetricrank, return it,
-        # and add a new column to comptable that contains this new metric
-        meanmetricrank, comptable = get_new_meanmetricrank(
-            comptable, comps2use, decision_node_idx
-        )
-
-        # Identify components that were either provionsally accepted
-        # or don't have a final classificaiton in prev_X_steps previous nodes
-        previous_comps2use = prev_classified_comps(
-            comptable,
-            decision_node_idx,
-            ["provisionalaccept", "provisionalreject", "unclassified"],
-            prev_X_steps=prev_X_steps,
-        )
-        previous_provaccept_comps2use = prev_classified_comps(
-            comptable,
-            decision_node_idx,
-            ["provisionalaccept"],
-            prev_X_steps=prev_X_steps,
-        )
-
-        kappa_elbow = kappa_elbow_kundu(comptable, n_echos)
-
-        # This should be the same as the MEICA 2.7 code except that I'm using provisionalaccept
-        # instead of >kappa_eblow and <rho_elbow, which si how provisionally accepted components
-        # are initially classified
-        num_acc_guess = int(
-            np.mean(
-                [
-                    len(previous_provaccept_comps2use),
-                    np.sum(comptable.loc[previous_comps2use, "kappa"] > kappa_elbow),
-                ]
-            )
-        )
-
-        # a scaling factor that is either based on the number of volumes or can be
-        # directly assigned
-        extend_factor = get_extend_factor(n_vols=n_vols, extend_factor=extend_factor)
-
-        varex_upper_thresh = scoreatpercentile(
-            comptable.loc[previous_provaccept_comps2use, "variance explained"],
-            high_perc,
-        )
-
-        # get kappa ratio
-        acc_prov = prev_classified_comps(
-            comptable,
-            decision_node_idx,
-            ["provisionalaccept"],
-            prev_X_steps=prev_X_steps,
-        )
-        kappa_rate = (
-            np.nanmax(comptable.loc[acc_prov, "kappa"])
-            - np.nanmin(comptable.loc[acc_prov, "kappa"])
-        ) / (
-            np.nanmax(comptable.loc[acc_prov, "variance explained"])
-            - np.nanmin(comptable.loc[acc_prov, "variance explained"])
-        )
-        LGR.info(f"Kappa rate found to be {kappa_rate} from components " f"{acc_prov}")
-        comptable["kappa ratio"] = (
-            kappa_rate * comptable["variance explained"] / comptable["kappa"]
-        )
-
-        conservative_guess = num_acc_guess / restrict_factor
-        db_mmrank = meanmetricrank.loc[comps2use] > conservative_guess
-        db_kapparatio = comptable.loc[comps2use, "kappa ratio"] > (extend_factor * 2)
-        db_var_upper = comptable.loc[comps2use, "variance explained"] > (
-            varex_upper_thresh * extend_factor
-        )
-        decision_boolean = db_mmrank & db_kapparatio & db_var_upper
-
-        comptable = change_comptable_classifications(
-            comptable, ifTrue, ifFalse, decision_boolean, str(decision_node_idx)
-        )
-        numTrue = np.asarray(decision_boolean).sum()
-        numFalse = np.logical_not(decision_boolean).sum()
-        # print(('numTrue={}, numFalse={}, numcomps2use={}'.format(
-        #        numTrue, numFalse, len(comps2use))))
-
-        log_decision_tree_step(
-            function_name_idx,
-            comps2use,
-            numTrue=numTrue,
-            numFalse=numFalse,
-            ifTrue=ifTrue,
-            ifFalse=ifFalse,
-        )
-
-        dnode_outputs = create_dnode_outputs(
-            decision_node_idx,
-            used_metrics,
-            node_label,
-            numTrue,
-            numFalse,
-            n_echos=n_echos,
-            n_vols=n_vols,
-            varex_threshold=varex_upper_thresh,
-            restrict_factor=2,
-            prev_X_steps=prev_X_steps,
-            max_good_meanmetricrank=conservative_guess,
-            num_acc_guess=num_acc_guess,
-            extend_factor=extend_factor,
-        )
-
-    return comptable, dnode_outputs
-
-
-highvariance_highmeanmetricrank_highkapparatio.__doc__ = (
-    highvariance_highmeanmetricrank_highkapparatio.__doc__.format(**decision_docs)
-)
-
-
-def highvariance_highmeanmetricrank(
-    comptable,
-    decision_node_idx,
-    ifTrue,
-    ifFalse,
-    decide_comps,
-    n_echos,
-    n_vols=None,
-    low_perc=25,
-    high_perc=90,
-    extend_factor=None,
-    prev_X_steps=0,
-    recalc_varex_lower_thresh=False,
-    log_extra_report="",
-    log_extra_info="",
-    custom_node_label="",
-    only_used_metrics=False,
-):
-    """
-    Finds components with variance above a threshold,
-    a mean metric rank above a threshold, and kappa ratio above a threshold.
-    This would typically be used to identify borderline remaining components to reject.
-
-    Parameters
-    ----------
-    {comptable}
-    {decision_node_idx}
-    {ifTrue}
-    {ifFalse}
-    {decide_comps}
-    {n_echos}
-    {n_vols}
-    {extend_factor}
-    {prev_X_steps}
-    {log_extra}
-    {custom_node_label}
-    {only_used_metrics}
-
-    Returns
-    -------
-    {basicreturns}
-    """
-
-    used_metrics = [
-        "variance explained",
-        "kappa",
-        "rho",
-        "dice_FT2",
-        "signal-noise_t",
-        "countsigFT2",
-        "countnoise",
-    ]
-    if only_used_metrics:
-        return used_metrics
-
-    function_name_idx = (
-        "Step {}: highvariance_highmeanmetricrank_highkapparatio".format(
-            (decision_node_idx)
-        )
-    )
-    if custom_node_label:
-        node_label = custom_node_label
-    else:
-        node_label = "highvar highmeanmetricrank highkapparatio"
-
-    if log_extra_info:
-        LGR.info(log_extra_info)
-    if log_extra_report:
-        RepLGR.info(log_extra_report)
-    metrics_exist, missing_metrics = confirm_metrics_exist(
-        comptable, used_metrics, function_name=function_name_idx
-    )
-
-    comps2use = selectcomps2use(comptable, decide_comps)
-    if comps2use is None:
-        log_decision_tree_step(function_name_idx, comps2use, decide_comps=decide_comps)
-        numTrue = 0
-        numFalse = 0
-        dnode_outputs = create_dnode_outputs(
-            decision_node_idx, used_metrics, node_label, 0, 0
-        )
-    else:
-        # This will either identify a previously calculated revised meanmetricrank and
-        # return it or it will calculate a revised meanmetricrank, return it,
-        # and add a new column to comptable that contains this new metric
-        meanmetricrank, comptable = get_new_meanmetricrank(
-            comptable, comps2use, decision_node_idx
-        )
-
-        # Identify components that were either provionsally accepted
-        # or don't have a final classificaiton in prev_X_steps previous nodes
-        previous_comps2use = prev_classified_comps(
-            comptable,
-            decision_node_idx,
-            ["provisionalaccept", "provisionalreject", "unclassified"],
-            prev_X_steps=prev_X_steps,
-        )
-        previous_provaccept_comps2use = prev_classified_comps(
-            comptable,
-            decision_node_idx,
-            ["provisionalaccept"],
-            prev_X_steps=prev_X_steps,
-        )
-
-        kappa_elbow = kappa_elbow_kundu(comptable, n_echos)
-
-        # This should be the same as the MEICA 2.7 code except that I'm using provisionalaccept
-        # instead of >kappa_eblow and <rho_elbow, which si how provisionally accepted components
-        # are initially classified
-        num_acc_guess = int(
-            np.mean(
-                len(previous_provaccept_comps2use),
-                np.sum(comptable.loc[previous_comps2use, "kappa"] > kappa_elbow),
-            )
-        )
-
-        # a scaling factor that is either based on the number of volumes or can be
-        # directly assigned
-        extend_factor = get_extend_factor(n_vols=n_vols, extend_factor=extend_factor)
-
-        conservative_guess2 = num_acc_guess * high_perc / 100.0
-        db_mmrank = meanmetricrank.loc[comps2use] > conservative_guess2
-
-        if recalc_varex_lower_thresh:
-            # Note: In MEICA v2.7 code, the included components are:
-            # [comps2use[:num_acc_guess]]. That would only make sense if the
-            # components were sorted by variance and I don't think they were.
-            # even still, this would be the the same as shifting the percentile
-            # based on num_acc_guess. The threshold without num_acc_guess seems
-            # equally arbitry so just keeping that for simplicity.
-            varex_lower_thresh = scoreatpercentile(
-                comptable.loc[comps2use, "variance explained"], low_perc
-            )
-        else:
-            varex_lower_thresh = scoreatpercentile(
-                comptable.loc[previous_provaccept_comps2use, "variance explained"],
-                low_perc,
-            )
-
-        db_var_lower = comptable.loc[comps2use, "variance explained"] > (
-            varex_lower_thresh * extend_factor
-        )
-
-        decision_boolean = db_mmrank & db_var_lower
-
-        comptable = change_comptable_classifications(
-            comptable, ifTrue, ifFalse, decision_boolean, str(decision_node_idx)
-        )
-        numTrue = np.asarray(decision_boolean).sum()
-        numFalse = np.logical_not(decision_boolean).sum()
-        # print(('numTrue={}, numFalse={}, numcomps2use={}'.format(
-        #        numTrue, numFalse, len(comps2use))))
-
-        log_decision_tree_step(
-            function_name_idx,
-            comps2use,
-            numTrue=numTrue,
-            numFalse=numFalse,
-            ifTrue=ifTrue,
-            ifFalse=ifFalse,
-        )
-
-        dnode_outputs = create_dnode_outputs(
-            decision_node_idx,
-            used_metrics,
-            node_label,
-            numTrue,
-            numFalse,
-            n_echos=n_echos,
-            n_vols=n_vols,
-            varex_threshold=varex_lower_thresh,
-            prev_X_steps=prev_X_steps,
-            max_good_meanmetricrank=conservative_guess2,
-            num_acc_guess=num_acc_guess,
-            extend_factor=extend_factor,
-        )
-
-    return comptable, dnode_outputs
-
-
-highvariance_highmeanmetricrank.__doc__ = (
-    highvariance_highmeanmetricrank.__doc__.format(**decision_docs)
-)
-
-
-def highvariance_lowkappa(
-    comptable,
-    decision_node_idx,
-    ifTrue,
-    ifFalse,
-    decide_comps,
-    n_echos,
-    low_perc=25,
-    log_extra_report="",
-    log_extra_info="",
-    custom_node_label="",
-    only_used_metrics=False,
-):
-    """
-    Finds components with variance above a threshold,
-    a mean metric rank above a threshold, and kappa ratio above a threshold.
-    This would typically be used to identify borderline remaining components to reject.
-
-    Parameters
-    ----------
-    {comptable}
-    {decision_node_idx}
-    {ifTrue}
-    {ifFalse}
-    {decide_comps}
-    {n_echos}
-    {log_extra}
-    {custom_node_label}
-    {only_used_metrics}
-
-    Returns
-    -------
-    {basicreturns}
-    """
-
-    used_metrics = ["variance explained", "kappa"]
-    if only_used_metrics:
-        return used_metrics
-
-    function_name_idx = "Step {}: highvariance_lowkappa".format(decision_node_idx)
-    if custom_node_label:
-        node_label = custom_node_label
-    else:
-        node_label = "highvariance lowkappa"
-
-    if log_extra_info:
-        LGR.info(log_extra_info)
-    if log_extra_report:
-        RepLGR.info(log_extra_report)
-    metrics_exist, missing_metrics = confirm_metrics_exist(
-        comptable, used_metrics, function_name=function_name_idx
-    )
-
-    comps2use = selectcomps2use(comptable, decide_comps)
-    if comps2use is None:
-        log_decision_tree_step(function_name_idx, comps2use, decide_comps=decide_comps)
-        numTrue = 0
-        numFalse = 0
-        dnode_outputs = create_dnode_outputs(
-            decision_node_idx, used_metrics, node_label, 0, 0
-        )
-    else:
-        kappa_elbow = kappa_elbow_kundu(comptable, n_echos)
-        db_kappa = comptable.loc[comps2use, "kappa"] <= kappa_elbow
-
-        # Note: In MEICA v2.7 code, the included components are:
-        # [comps2use[:num_acc_guess]]. That would only make sense if the
-        # components were sorted by variance and I don't think they were.
-        # even still, this would be the the same as shifting the percentile
-        # based on num_acc_guess. The threshold without num_acc_guess seems
-        # equally arbitry so just keeping that for simplicity.
-        varex_lower_thresh = scoreatpercentile(
-            comptable.loc[comps2use, "variance explained"], low_perc
-        )
-
-        db_var_lower = (
-            comptable.loc[comps2use, "variance explained"] > varex_lower_thresh
-        )
-
-        decision_boolean = db_kappa & db_var_lower
-
-        comptable = change_comptable_classifications(
-            comptable, ifTrue, ifFalse, decision_boolean, str(decision_node_idx)
-        )
-        numTrue = np.asarray(decision_boolean).sum()
-        numFalse = np.logical_not(decision_boolean).sum()
-        # print(('numTrue={}, numFalse={}, numcomps2use={}'.format(
-        #        numTrue, numFalse, len(comps2use))))
-
-        log_decision_tree_step(
-            function_name_idx,
-            comps2use,
-            numTrue=numTrue,
-            numFalse=numFalse,
-            ifTrue=ifTrue,
-            ifFalse=ifFalse,
-        )
-
-        dnode_outputs = create_dnode_outputs(
-            decision_node_idx,
-            used_metrics,
-            node_label,
-            numTrue,
-            numFalse,
-            n_echos=n_echos,
-            varex_threshold=varex_lower_thresh,
-        )
-
-    return comptable, dnode_outputs
-
-
-highvariance_lowkappa.__doc__ = highvariance_lowkappa.__doc__.format(**decision_docs)
+# def classification_exists(
+#     comptable,
+#     decision_node_idx,
+#     ifTrue,
+#     ifFalse,
+#     decide_comps,
+#     class_comp_exists,
+#     log_extra_report="",
+#     log_extra_info="",
+#     custom_node_label="",
+#     only_used_metrics=False,
+# ):
+#     """
+#     If there are not compontents with a classification specified in class_comp_exists,
+#     change the classification of all components in decide_comps
+#     Parameters
+#     ----------
+#     {comptable}
+#     {decision_node_idx}
+#     {ifTrue}
+#     {ifFalse}
+#     {decide_comps}
+#     class_comp_exists: :obj:`str` or :obj:`list[str]` or :obj:`int` or :obj:`list[int]`
+#         This has the same structure options as decide_comps. This function tests
+#         whether any components have the classifications defined in this variable.
+#     {log_extra}
+#     {custom_node_label}
+#     {only_used_metrics}
+
+#     Returns
+#     -------
+#     {basicreturns}
+
+#     """
+
+#     used_metrics = []
+#     if only_used_metrics:
+#         return used_metrics
+
+#     function_name_idx = "Step {}: classification_exists".format(decision_node_idx)
+#     if custom_node_label:
+#         node_label = custom_node_label
+#     else:
+#         node_label = "Change {} if {} doesn't exist".format(
+#             decide_comps, classification_exists
+#         )
+
+#     # Might want to add additional default logging to functions here
+#     # The function input will be logged before the function call
+#     if log_extra_info:
+#         LGR.info(log_extra_info)
+#     if log_extra_report:
+#         RepLGR.info(log_extra_report)
+
+#     comps2use = selectcomps2use(comptable, decide_comps)
+#     do_comps_exist = selectcomps2use(comptable, class_comp_exists)
+
+#     if comps2use is None:
+#         log_decision_tree_step(function_name_idx, comps2use, decide_comps=decide_comps)
+#         numTrue = 0
+#         numFalse = 0
+#     elif do_comps_exist is None:
+#         # should be false for all components
+#         decision_boolean = comptable.loc[comps2use, "component"] < -100
+#         comptable = change_comptable_classifications(
+#             comptable, ifTrue, ifFalse, decision_boolean, str(decision_node_idx)
+#         )
+#         numTrue = np.asarray(decision_boolean).sum()
+#         # numtrue should always be 0 in this situation
+#         numFalse = np.logical_not(decision_boolean).sum()
+#         # print(('numTrue={}, numFalse={}, numcomps2use={}'.format(
+#         #    numTrue, numFalse, len(comps2use))))
+#         log_decision_tree_step(
+#             function_name_idx,
+#             comps2use,
+#             numTrue=numTrue,
+#             numFalse=numFalse,
+#             ifTrue=ifTrue,
+#             ifFalse=ifFalse,
+#         )
+#     else:
+#         numTrue = len(comps2use)
+#         numFalse = 0
+#         log_decision_tree_step(
+#             function_name_idx,
+#             comps2use,
+#             numTrue=numTrue,
+#             numFalse=numFalse,
+#             ifTrue=ifTrue,
+#             ifFalse=ifFalse,
+#         )
+
+#     dnode_outputs = create_dnode_outputs(
+#         decision_node_idx, used_metrics, node_label, numTrue, numFalse
+#     )
+
+#     return comptable, dnode_outputs
+
+
+# def meanmetricrank_and_variance_greaterthan_thresh(
+#     comptable,
+#     decision_node_idx,
+#     ifTrue,
+#     ifFalse,
+#     decide_comps,
+#     n_vols,
+#     high_perc=90,
+#     extend_factor=None,
+#     log_extra_report="",
+#     log_extra_info="",
+#     custom_node_label="",
+#     only_used_metrics=False,
+# ):
+#     """
+#     The 'mean metric rank' (formerly d_table) is the mean of rankings of 5 metrics:
+#         'kappa', 'dice_FT2', 'signal-noise_t',
+#         and 'countnoise', 'countsigFT2'
+#     For these 5 metrics, a lower rank (smaller number) is less likely to be
+#     T2* weighted.
+#     This function tests of meanmetricrank is above a threshold based on the number
+#     of provisionally accepted components & variance based on a threshold related
+#     to the variance of provisionally accepted components. This is indented to
+#     reject components that are greater than both of these thresholds
+
+#     Parameters
+#     ----------
+#     {comptable}
+#     {decision_node_idx}
+#     {ifTrue}
+#     {ifFalse}
+#     {decide_comps}
+#     {n_vols}
+#     high_perc: :obj:`int`
+#         A percentile threshold to apply to components to set the variance
+#         threshold. default=90
+#     {extend_factor}
+#     {log_extra}
+#     {custom_node_label}
+#     {only_used_metrics}
+
+#     Returns
+#     -------
+#     {basicreturns}
+#     dnode_ouputs also contains:
+#     num_prov_accept: :obj:`int`
+#         Number of provisionally accepted components
+#     max_good_meanmetricrank: :obj:`float`
+#         The threshold used meanmetricrank
+#     varex_threshold: :obj:`float`
+#         The threshold used for variance
+#     """
+
+#     used_metrics = ["d_table_score", "variance explained"]
+#     if only_used_metrics:
+#         return used_metrics
+
+#     function_name_idx = (
+#         "Step {}: meanmetricrank_and_variance_greaterthan_thresh".format(
+#             decision_node_idx
+#         )
+#     )
+#     if custom_node_label:
+#         node_label = custom_node_label
+#     else:
+#         node_label = "MeanRank & Variance Thresholding"
+
+#     if log_extra_info:
+#         LGR.info(log_extra_info)
+#     if log_extra_report:
+#         RepLGR.info(log_extra_report)
+
+#     metrics_exist, missing_metrics = confirm_metrics_exist(
+#         comptable, used_metrics, function_name=function_name_idx
+#     )
+
+#     comps2use = selectcomps2use(comptable, decide_comps)
+#     provaccept_comps2use = selectcomps2use(comptable, ["provisionalaccept"])
+#     if (comps2use is None) or (provaccept_comps2use is None):
+#         if comps2use is None:
+#             log_decision_tree_step(
+#                 function_name_idx, comps2use, decide_comps=decide_comps
+#             )
+#         if provaccept_comps2use is None:
+#             log_decision_tree_step(
+#                 function_name_idx, comps2use, decide_comps="provisionalaccept"
+#             )
+#         dnode_outputs = create_dnode_outputs(
+#             decision_node_idx, used_metrics, node_label, 0, 0
+#         )
+#     else:
+#         num_prov_accept = len(provaccept_comps2use)
+#         varex_upper_thresh = scoreatpercentile(
+#             comptable.loc[provaccept_comps2use, "variance explained"], high_perc
+#         )
+
+#         extend_factor = get_extend_factor(n_vols=n_vols, extend_factor=extend_factor)
+#         max_good_meanmetricrank = extend_factor * num_prov_accept
+
+#         decision_boolean1 = (
+#             comptable.loc[comps2use, "d_table_score"] > max_good_meanmetricrank
+#         )
+#         decision_boolean2 = (
+#             comptable.loc[comps2use, "variance explained"] > varex_upper_thresh
+#         )
+#         decision_boolean = decision_boolean1 & decision_boolean2
+
+#         comptable = change_comptable_classifications(
+#             comptable, ifTrue, ifFalse, decision_boolean, str(decision_node_idx)
+#         )
+#         numTrue = np.asarray(decision_boolean).sum()
+#         numFalse = np.logical_not(decision_boolean).sum()
+#         # print(('numTrue={}, numFalse={}, numcomps2use={}'.format(
+#         #    numTrue, numFalse, len(comps2use))))
+#         log_decision_tree_step(
+#             function_name_idx,
+#             comps2use,
+#             numTrue=numTrue,
+#             numFalse=numFalse,
+#             ifTrue=ifTrue,
+#             ifFalse=ifFalse,
+#         )
+
+#         dnode_outputs = create_dnode_outputs(
+#             decision_node_idx,
+#             used_metrics,
+#             node_label,
+#             numTrue,
+#             numFalse,
+#             num_prov_accept=num_prov_accept,
+#             varex_threshold=varex_upper_thresh,
+#             max_good_meanmetricrank=max_good_meanmetricrank,
+#             extend_factor=extend_factor,
+#         )
+
+#     return comptable, dnode_outputs
+
+
+# meanmetricrank_and_variance_greaterthan_thresh.__doc__ = (
+#     meanmetricrank_and_variance_greaterthan_thresh.__doc__.format(**decision_docs)
+# )
+
+
+# def lowvariance_highmeanmetricrank_lowkappa(
+#     comptable,
+#     decision_node_idx,
+#     ifTrue,
+#     ifFalse,
+#     decide_comps,
+#     n_echos,
+#     n_vols,
+#     low_perc=25,
+#     extend_factor=None,
+#     log_extra_report="",
+#     log_extra_info="",
+#     custom_node_label="",
+#     only_used_metrics=False,
+# ):
+#     """
+#     Finds components with variance below a threshold,
+#     a mean metric rank above a threshold, and kappa below a threshold.
+#     This would typically be used to identify remaining components that would
+#     otherwise be rejected & put them in accept with a 'low variance' tag
+
+#     Parameters
+#     ----------
+#     {comptable}
+#     {decision_node_idx}
+#     {ifTrue}
+#     {ifFalse}
+#     {decide_comps}
+#     {n_echos}
+#     {n_vols}
+#     {extend_factor}
+#     {log_extra}
+#     {custom_node_label}
+#     {only_used_metrics}
+
+#     Returns
+#     -------
+#     {basicreturns}
+#     """
+
+#     used_metrics = ["variance explained", "kappa", "d_table_score"]
+#     if only_used_metrics:
+#         return used_metrics
+
+#     function_name_idx = "Step {}: lowvariance_highmeanmetricrank_lowkappa".format(
+#         decision_node_idx
+#     )
+#     if custom_node_label:
+#         node_label = custom_node_label
+#     else:
+#         node_label = "lowvar highmeanmetricrank lowkappa"
+
+#     if log_extra_info:
+#         LGR.info(log_extra_info)
+#     if log_extra_report:
+#         RepLGR.info(log_extra_report)
+#     metrics_exist, missing_metrics = confirm_metrics_exist(
+#         comptable, used_metrics, function_name=function_name_idx
+#     )
+
+#     comps2use = selectcomps2use(comptable, decide_comps)
+#     provaccept_comps2use = selectcomps2use(comptable, ["provisionalaccept"])
+
+#     if (comps2use is None) or (provaccept_comps2use is None):
+#         if comps2use is None:
+#             log_decision_tree_step(
+#                 function_name_idx, comps2use, decide_comps=decide_comps
+#             )
+#         if provaccept_comps2use is None:
+#             log_decision_tree_step(
+#                 function_name_idx, comps2use, decide_comps="provisionalaccept"
+#             )
+#         dnode_outputs = create_dnode_outputs(
+#             decision_node_idx, used_metrics, node_label, 0, 0
+#         )
+#     else:
+#         # low variance threshold
+#         varex_lower_thresh = scoreatpercentile(
+#             comptable.loc[provaccept_comps2use, "variance explained"], low_perc
+#         )
+#         db_low_varex = (
+#             comptable.loc[comps2use, "variance explained"] < varex_lower_thresh
+#         )
+
+#         # mean metric rank threshold
+#         num_prov_accept = len(provaccept_comps2use)
+#         extend_factor = get_extend_factor(n_vols=n_vols, extend_factor=extend_factor)
+#         max_good_meanmetricrank = extend_factor * num_prov_accept
+#         db_meanmetricrank = (
+#             comptable.loc[comps2use, "d_table_score"] < max_good_meanmetricrank
+#         )
+
+#         # kappa threshold
+#         kappa_elbow = kappa_elbow_kundu(comptable, n_echos)
+#         db_kappa = comptable.loc[comps2use, "kappa"] > kappa_elbow
+
+#         # combine the 3 thresholds
+#         decision_boolean = db_low_varex & db_meanmetricrank & db_kappa
+
+#         comptable = change_comptable_classifications(
+#             comptable, ifTrue, ifFalse, decision_boolean, str(decision_node_idx)
+#         )
+#         numTrue = np.asarray(decision_boolean).sum()
+#         numFalse = np.logical_not(decision_boolean).sum()
+#         # print(('numTrue={}, numFalse={}, numcomps2use={}'.format(
+#         #    numTrue, numFalse, len(comps2use))))
+
+#         log_decision_tree_step(
+#             function_name_idx,
+#             comps2use,
+#             numTrue=numTrue,
+#             numFalse=numFalse,
+#             ifTrue=ifTrue,
+#             ifFalse=ifFalse,
+#         )
+
+#         dnode_outputs = create_dnode_outputs(
+#             decision_node_idx,
+#             used_metrics,
+#             node_label,
+#             numTrue,
+#             numFalse,
+#             n_echos=n_echos,
+#             n_vols=n_vols,
+#             kappa_elbow=kappa_elbow,
+#             varex_threshold=varex_lower_thresh,
+#             max_good_meanmetricrank=max_good_meanmetricrank,
+#             num_prov_accept=num_prov_accept,
+#             extend_factor=extend_factor,
+#         )
+
+#     return comptable, dnode_outputs
+
+
+# lowvariance_highmeanmetricrank_lowkappa.__doc__ = (
+#     lowvariance_highmeanmetricrank_lowkappa.__doc__.format(**decision_docs)
+# )
+
+
+# def highvariance_highmeanmetricrank_highkapparatio(
+#     comptable,
+#     decision_node_idx,
+#     ifTrue,
+#     ifFalse,
+#     decide_comps,
+#     n_echos,
+#     n_vols=None,
+#     extend_factor=None,
+#     restrict_factor=2,
+#     prev_X_steps=0,
+#     high_perc=90,
+#     log_extra_report="",
+#     log_extra_info="",
+#     custom_node_label="",
+#     only_used_metrics=False,
+# ):
+#     """
+#     Finds components with variance above a threshold,
+#     a mean metric rank above a threshold, and kappa ratio above a threshold.
+#     This would typically be used to identify borderline remaining components to reject.
+
+#     Parameters
+#     ----------
+#     {comptable}
+#     {decision_node_idx}
+#     {ifTrue}
+#     {ifFalse}
+#     {decide_comps}
+#     {n_echos}
+#     {n_vols}
+#     {extend_factor}
+#     {restrict_factor}
+#     {prev_X_steps}
+#     {log_extra}
+#     {custom_node_label}
+#     {only_used_metrics}
+
+#     Returns
+#     -------
+#     {basicreturns}
+#     """
+
+#     used_metrics = [
+#         "variance explained",
+#         "kappa",
+#         "rho",
+#         "dice_FT2",
+#         "signal-noise_t",
+#         "countsigFT2",
+#         "countnoise",
+#     ]
+#     if only_used_metrics:
+#         return used_metrics
+
+#     function_name_idx = (
+#         "Step {}: highvariance_highmeanmetricrank_highkapparatio".format(
+#             decision_node_idx
+#         )
+#     )
+#     if custom_node_label:
+#         node_label = custom_node_label
+#     else:
+#         node_label = "highvar highmeanmetricrank highkapparatio"
+
+#     if log_extra_info:
+#         LGR.info(log_extra_info)
+#     if log_extra_report:
+#         RepLGR.info(log_extra_report)
+#     metrics_exist, missing_metrics = confirm_metrics_exist(
+#         comptable, used_metrics, function_name=function_name_idx
+#     )
+
+#     comps2use = selectcomps2use(comptable, decide_comps)
+#     if comps2use is None:
+#         log_decision_tree_step(function_name_idx, comps2use, decide_comps=decide_comps)
+#         numTrue = 0
+#         numFalse = 0
+#         dnode_outputs = create_dnode_outputs(
+#             decision_node_idx, used_metrics, node_label, 0, 0
+#         )
+#     else:
+#         # This will either identify a previously calculated revised meanmetricrank and
+#         # return it or it will calculate a revised meanmetricrank, return it,
+#         # and add a new column to comptable that contains this new metric
+#         meanmetricrank, comptable = get_new_meanmetricrank(
+#             comptable, comps2use, decision_node_idx
+#         )
+
+#         # Identify components that were either provionsally accepted
+#         # or don't have a final classificaiton in prev_X_steps previous nodes
+#         previous_comps2use = prev_classified_comps(
+#             comptable,
+#             decision_node_idx,
+#             ["provisionalaccept", "provisionalreject", "unclassified"],
+#             prev_X_steps=prev_X_steps,
+#         )
+#         previous_provaccept_comps2use = prev_classified_comps(
+#             comptable,
+#             decision_node_idx,
+#             ["provisionalaccept"],
+#             prev_X_steps=prev_X_steps,
+#         )
+
+#         kappa_elbow = kappa_elbow_kundu(comptable, n_echos)
+
+#         # This should be the same as the MEICA 2.7 code except that I'm using provisionalaccept
+#         # instead of >kappa_eblow and <rho_elbow, which si how provisionally accepted components
+#         # are initially classified
+#         num_acc_guess = int(
+#             np.mean(
+#                 [
+#                     len(previous_provaccept_comps2use),
+#                     np.sum(comptable.loc[previous_comps2use, "kappa"] > kappa_elbow),
+#                 ]
+#             )
+#         )
+
+#         # a scaling factor that is either based on the number of volumes or can be
+#         # directly assigned
+#         extend_factor = get_extend_factor(n_vols=n_vols, extend_factor=extend_factor)
+
+#         varex_upper_thresh = scoreatpercentile(
+#             comptable.loc[previous_provaccept_comps2use, "variance explained"],
+#             high_perc,
+#         )
+
+#         # get kappa ratio
+#         acc_prov = prev_classified_comps(
+#             comptable,
+#             decision_node_idx,
+#             ["provisionalaccept"],
+#             prev_X_steps=prev_X_steps,
+#         )
+#         kappa_rate = (
+#             np.nanmax(comptable.loc[acc_prov, "kappa"])
+#             - np.nanmin(comptable.loc[acc_prov, "kappa"])
+#         ) / (
+#             np.nanmax(comptable.loc[acc_prov, "variance explained"])
+#             - np.nanmin(comptable.loc[acc_prov, "variance explained"])
+#         )
+#         LGR.info(f"Kappa rate found to be {kappa_rate} from components " f"{acc_prov}")
+#         comptable["kappa ratio"] = (
+#             kappa_rate * comptable["variance explained"] / comptable["kappa"]
+#         )
+
+#         conservative_guess = num_acc_guess / restrict_factor
+#         db_mmrank = meanmetricrank.loc[comps2use] > conservative_guess
+#         db_kapparatio = comptable.loc[comps2use, "kappa ratio"] > (extend_factor * 2)
+#         db_var_upper = comptable.loc[comps2use, "variance explained"] > (
+#             varex_upper_thresh * extend_factor
+#         )
+#         decision_boolean = db_mmrank & db_kapparatio & db_var_upper
+
+#         comptable = change_comptable_classifications(
+#             comptable, ifTrue, ifFalse, decision_boolean, str(decision_node_idx)
+#         )
+#         numTrue = np.asarray(decision_boolean).sum()
+#         numFalse = np.logical_not(decision_boolean).sum()
+#         # print(('numTrue={}, numFalse={}, numcomps2use={}'.format(
+#         #        numTrue, numFalse, len(comps2use))))
+
+#         log_decision_tree_step(
+#             function_name_idx,
+#             comps2use,
+#             numTrue=numTrue,
+#             numFalse=numFalse,
+#             ifTrue=ifTrue,
+#             ifFalse=ifFalse,
+#         )
+
+#         dnode_outputs = create_dnode_outputs(
+#             decision_node_idx,
+#             used_metrics,
+#             node_label,
+#             numTrue,
+#             numFalse,
+#             n_echos=n_echos,
+#             n_vols=n_vols,
+#             varex_threshold=varex_upper_thresh,
+#             restrict_factor=2,
+#             prev_X_steps=prev_X_steps,
+#             max_good_meanmetricrank=conservative_guess,
+#             num_acc_guess=num_acc_guess,
+#             extend_factor=extend_factor,
+#         )
+
+#     return comptable, dnode_outputs
+
+
+# highvariance_highmeanmetricrank_highkapparatio.__doc__ = (
+#     highvariance_highmeanmetricrank_highkapparatio.__doc__.format(**decision_docs)
+# )
+
+
+# def highvariance_highmeanmetricrank(
+#     comptable,
+#     decision_node_idx,
+#     ifTrue,
+#     ifFalse,
+#     decide_comps,
+#     n_echos,
+#     n_vols=None,
+#     low_perc=25,
+#     high_perc=90,
+#     extend_factor=None,
+#     prev_X_steps=0,
+#     recalc_varex_lower_thresh=False,
+#     log_extra_report="",
+#     log_extra_info="",
+#     custom_node_label="",
+#     only_used_metrics=False,
+# ):
+#     """
+#     Finds components with variance above a threshold,
+#     a mean metric rank above a threshold, and kappa ratio above a threshold.
+#     This would typically be used to identify borderline remaining components to reject.
+
+#     Parameters
+#     ----------
+#     {comptable}
+#     {decision_node_idx}
+#     {ifTrue}
+#     {ifFalse}
+#     {decide_comps}
+#     {n_echos}
+#     {n_vols}
+#     {extend_factor}
+#     {prev_X_steps}
+#     {log_extra}
+#     {custom_node_label}
+#     {only_used_metrics}
+
+#     Returns
+#     -------
+#     {basicreturns}
+#     """
+
+#     used_metrics = [
+#         "variance explained",
+#         "kappa",
+#         "rho",
+#         "dice_FT2",
+#         "signal-noise_t",
+#         "countsigFT2",
+#         "countnoise",
+#     ]
+#     if only_used_metrics:
+#         return used_metrics
+
+#     function_name_idx = (
+#         "Step {}: highvariance_highmeanmetricrank_highkapparatio".format(
+#             (decision_node_idx)
+#         )
+#     )
+#     if custom_node_label:
+#         node_label = custom_node_label
+#     else:
+#         node_label = "highvar highmeanmetricrank highkapparatio"
+
+#     if log_extra_info:
+#         LGR.info(log_extra_info)
+#     if log_extra_report:
+#         RepLGR.info(log_extra_report)
+#     metrics_exist, missing_metrics = confirm_metrics_exist(
+#         comptable, used_metrics, function_name=function_name_idx
+#     )
+
+#     comps2use = selectcomps2use(comptable, decide_comps)
+#     if comps2use is None:
+#         log_decision_tree_step(function_name_idx, comps2use, decide_comps=decide_comps)
+#         numTrue = 0
+#         numFalse = 0
+#         dnode_outputs = create_dnode_outputs(
+#             decision_node_idx, used_metrics, node_label, 0, 0
+#         )
+#     else:
+#         # This will either identify a previously calculated revised meanmetricrank and
+#         # return it or it will calculate a revised meanmetricrank, return it,
+#         # and add a new column to comptable that contains this new metric
+#         meanmetricrank, comptable = get_new_meanmetricrank(
+#             comptable, comps2use, decision_node_idx
+#         )
+
+#         # Identify components that were either provionsally accepted
+#         # or don't have a final classificaiton in prev_X_steps previous nodes
+#         previous_comps2use = prev_classified_comps(
+#             comptable,
+#             decision_node_idx,
+#             ["provisionalaccept", "provisionalreject", "unclassified"],
+#             prev_X_steps=prev_X_steps,
+#         )
+#         previous_provaccept_comps2use = prev_classified_comps(
+#             comptable,
+#             decision_node_idx,
+#             ["provisionalaccept"],
+#             prev_X_steps=prev_X_steps,
+#         )
+
+#         kappa_elbow = kappa_elbow_kundu(comptable, n_echos)
+
+#         # This should be the same as the MEICA 2.7 code except that I'm using provisionalaccept
+#         # instead of >kappa_eblow and <rho_elbow, which si how provisionally accepted components
+#         # are initially classified
+#         num_acc_guess = int(
+#             np.mean(
+#                 len(previous_provaccept_comps2use),
+#                 np.sum(comptable.loc[previous_comps2use, "kappa"] > kappa_elbow),
+#             )
+#         )
+
+#         # a scaling factor that is either based on the number of volumes or can be
+#         # directly assigned
+#         extend_factor = get_extend_factor(n_vols=n_vols, extend_factor=extend_factor)
+
+#         conservative_guess2 = num_acc_guess * high_perc / 100.0
+#         db_mmrank = meanmetricrank.loc[comps2use] > conservative_guess2
+
+#         if recalc_varex_lower_thresh:
+#             # Note: In MEICA v2.7 code, the included components are:
+#             # [comps2use[:num_acc_guess]]. That would only make sense if the
+#             # components were sorted by variance and I don't think they were.
+#             # even still, this would be the the same as shifting the percentile
+#             # based on num_acc_guess. The threshold without num_acc_guess seems
+#             # equally arbitry so just keeping that for simplicity.
+#             varex_lower_thresh = scoreatpercentile(
+#                 comptable.loc[comps2use, "variance explained"], low_perc
+#             )
+#         else:
+#             varex_lower_thresh = scoreatpercentile(
+#                 comptable.loc[previous_provaccept_comps2use, "variance explained"],
+#                 low_perc,
+#             )
+
+#         db_var_lower = comptable.loc[comps2use, "variance explained"] > (
+#             varex_lower_thresh * extend_factor
+#         )
+
+#         decision_boolean = db_mmrank & db_var_lower
+
+#         comptable = change_comptable_classifications(
+#             comptable, ifTrue, ifFalse, decision_boolean, str(decision_node_idx)
+#         )
+#         numTrue = np.asarray(decision_boolean).sum()
+#         numFalse = np.logical_not(decision_boolean).sum()
+#         # print(('numTrue={}, numFalse={}, numcomps2use={}'.format(
+#         #        numTrue, numFalse, len(comps2use))))
+
+#         log_decision_tree_step(
+#             function_name_idx,
+#             comps2use,
+#             numTrue=numTrue,
+#             numFalse=numFalse,
+#             ifTrue=ifTrue,
+#             ifFalse=ifFalse,
+#         )
+
+#         dnode_outputs = create_dnode_outputs(
+#             decision_node_idx,
+#             used_metrics,
+#             node_label,
+#             numTrue,
+#             numFalse,
+#             n_echos=n_echos,
+#             n_vols=n_vols,
+#             varex_threshold=varex_lower_thresh,
+#             prev_X_steps=prev_X_steps,
+#             max_good_meanmetricrank=conservative_guess2,
+#             num_acc_guess=num_acc_guess,
+#             extend_factor=extend_factor,
+#         )
+
+#     return comptable, dnode_outputs
+
+
+# highvariance_highmeanmetricrank.__doc__ = (
+#     highvariance_highmeanmetricrank.__doc__.format(**decision_docs)
+# )
+
+
+# def highvariance_lowkappa(
+#     comptable,
+#     decision_node_idx,
+#     ifTrue,
+#     ifFalse,
+#     decide_comps,
+#     n_echos,
+#     low_perc=25,
+#     log_extra_report="",
+#     log_extra_info="",
+#     custom_node_label="",
+#     only_used_metrics=False,
+# ):
+#     """
+#     Finds components with variance above a threshold,
+#     a mean metric rank above a threshold, and kappa ratio above a threshold.
+#     This would typically be used to identify borderline remaining components to reject.
+
+#     Parameters
+#     ----------
+#     {comptable}
+#     {decision_node_idx}
+#     {ifTrue}
+#     {ifFalse}
+#     {decide_comps}
+#     {n_echos}
+#     {log_extra}
+#     {custom_node_label}
+#     {only_used_metrics}
+
+#     Returns
+#     -------
+#     {basicreturns}
+#     """
+
+#     used_metrics = ["variance explained", "kappa"]
+#     if only_used_metrics:
+#         return used_metrics
+
+#     function_name_idx = "Step {}: highvariance_lowkappa".format(decision_node_idx)
+#     if custom_node_label:
+#         node_label = custom_node_label
+#     else:
+#         node_label = "highvariance lowkappa"
+
+#     if log_extra_info:
+#         LGR.info(log_extra_info)
+#     if log_extra_report:
+#         RepLGR.info(log_extra_report)
+#     metrics_exist, missing_metrics = confirm_metrics_exist(
+#         comptable, used_metrics, function_name=function_name_idx
+#     )
+
+#     comps2use = selectcomps2use(comptable, decide_comps)
+#     if comps2use is None:
+#         log_decision_tree_step(function_name_idx, comps2use, decide_comps=decide_comps)
+#         numTrue = 0
+#         numFalse = 0
+#         dnode_outputs = create_dnode_outputs(
+#             decision_node_idx, used_metrics, node_label, 0, 0
+#         )
+#     else:
+#         kappa_elbow = kappa_elbow_kundu(comptable, n_echos)
+#         db_kappa = comptable.loc[comps2use, "kappa"] <= kappa_elbow
+
+#         # Note: In MEICA v2.7 code, the included components are:
+#         # [comps2use[:num_acc_guess]]. That would only make sense if the
+#         # components were sorted by variance and I don't think they were.
+#         # even still, this would be the the same as shifting the percentile
+#         # based on num_acc_guess. The threshold without num_acc_guess seems
+#         # equally arbitry so just keeping that for simplicity.
+#         varex_lower_thresh = scoreatpercentile(
+#             comptable.loc[comps2use, "variance explained"], low_perc
+#         )
+
+#         db_var_lower = (
+#             comptable.loc[comps2use, "variance explained"] > varex_lower_thresh
+#         )
+
+#         decision_boolean = db_kappa & db_var_lower
+
+#         comptable = change_comptable_classifications(
+#             comptable, ifTrue, ifFalse, decision_boolean, str(decision_node_idx)
+#         )
+#         numTrue = np.asarray(decision_boolean).sum()
+#         numFalse = np.logical_not(decision_boolean).sum()
+#         # print(('numTrue={}, numFalse={}, numcomps2use={}'.format(
+#         #        numTrue, numFalse, len(comps2use))))
+
+#         log_decision_tree_step(
+#             function_name_idx,
+#             comps2use,
+#             numTrue=numTrue,
+#             numFalse=numFalse,
+#             ifTrue=ifTrue,
+#             ifFalse=ifFalse,
+#         )
+
+#         dnode_outputs = create_dnode_outputs(
+#             decision_node_idx,
+#             used_metrics,
+#             node_label,
+#             numTrue,
+#             numFalse,
+#             n_echos=n_echos,
+#             varex_threshold=varex_lower_thresh,
+#         )
+
+#     return comptable, dnode_outputs
+
+
+# highvariance_lowkappa.__doc__ = highvariance_lowkappa.__doc__.format(**decision_docs)

--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -11,8 +11,9 @@ from tedana.selection._utils import clean_dataframe
 from tedana.metrics import collect
 
 LGR = logging.getLogger("GENERAL")
-RepLGR = logging.getLogger('REPORT')
-RefLGR = logging.getLogger('REFERENCES')
+RepLGR = logging.getLogger("REPORT")
+RefLGR = logging.getLogger("REFERENCES")
+
 
 def manual_selection(comptable, acc=None, rej=None):
     """
@@ -35,17 +36,21 @@ def manual_selection(comptable, acc=None, rej=None):
         Dictionary with metadata about calculated metrics.
         Each entry corresponds to a column in ``comptable``.
     """
-    LGR.info('Performing manual ICA component selection')
-    RepLGR.info("Next, components were manually classified as "
-                "BOLD (TE-dependent), non-BOLD (TE-independent), or "
-                "uncertain (low-variance).")
-    if ('classification' in comptable.columns and
-            'original_classification' not in comptable.columns):
-        comptable['original_classification'] = comptable['classification']
-        comptable['original_rationale'] = comptable['rationale']
+    LGR.info("Performing manual ICA component selection")
+    RepLGR.info(
+        "Next, components were manually classified as "
+        "BOLD (TE-dependent), non-BOLD (TE-independent), or "
+        "uncertain (low-variance)."
+    )
+    if (
+        "classification" in comptable.columns
+        and "original_classification" not in comptable.columns
+    ):
+        comptable["original_classification"] = comptable["classification"]
+        comptable["original_rationale"] = comptable["rationale"]
 
-    comptable['classification'] = 'accepted'
-    comptable['rationale'] = ''
+    comptable["classification"] = "accepted"
+    comptable["rationale"] = ""
 
     all_comps = comptable.index.values
     if acc is not None:
@@ -59,25 +64,28 @@ def manual_selection(comptable, acc=None, rej=None):
     elif acc is None and rej is not None:
         acc = sorted(np.setdiff1d(all_comps, rej))
     elif acc is None and rej is None:
-        LGR.info('No manually accepted or rejected components supplied. '
-                 'Accepting all components.')
+        LGR.info(
+            "No manually accepted or rejected components supplied. "
+            "Accepting all components."
+        )
         # Accept all components if no manual selection provided
         acc = all_comps[:]
         rej = []
 
     ign = np.setdiff1d(all_comps, np.union1d(acc, rej))
-    comptable.loc[acc, 'classification'] = 'accepted'
-    comptable.loc[rej, 'classification'] = 'rejected'
-    comptable.loc[rej, 'rationale'] += 'I001;'
-    comptable.loc[ign, 'classification'] = 'ignored'
-    comptable.loc[ign, 'rationale'] += 'I001;'
+    comptable.loc[acc, "classification"] = "accepted"
+    comptable.loc[rej, "classification"] = "rejected"
+    comptable.loc[rej, "rationale"] += "I001;"
+    comptable.loc[ign, "classification"] = "ignored"
+    comptable.loc[ign, "rationale"] += "I001;"
 
     # Move decision columns to end
     comptable = clean_dataframe(comptable)
     metric_metadata = collect.get_metadata(comptable)
     return comptable, metric_metadata
 
-def automatic_selection(comptable, n_echos, n_vols, tree='simple'):
+
+def automatic_selection(comptable, n_echos, n_vols, tree="simple"):
     """Classify components based on component table and tree type.
 
     Parameters
@@ -98,9 +106,9 @@ def automatic_selection(comptable, n_echos, n_vols, tree='simple'):
     --------
     DecisionTree, the class used to represent the classification process
     """
-    comptable['rationale'] = ''
+    comptable["rationale"] = ""
     dt = DecisionTree(tree, comptable, n_echos=n_echos, n_vols=n_vols)
-    comptable, _ = dt.run()
-    metadata = collect.get_metadata(comptable)
+    component_table, cross_component_metrics, component_status_table, _ = dt.run()
+    metadata = collect.get_metadata(component_table)
 
-    return comptable, metadata
+    return component_table, cross_component_metrics, component_status_table, metadata

--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -47,10 +47,10 @@ def manual_selection(comptable, acc=None, rej=None):
         and "original_classification" not in comptable.columns
     ):
         comptable["original_classification"] = comptable["classification"]
-        comptable["original_rationale"] = comptable["rationale"]
+        # comptable["original_rationale"] = comptable["rationale"]
 
     comptable["classification"] = "accepted"
-    comptable["rationale"] = ""
+    # comptable["rationale"] = ""
 
     all_comps = comptable.index.values
     if acc is not None:
@@ -106,7 +106,7 @@ def automatic_selection(comptable, n_echos, n_vols, tree="simple"):
     --------
     ComponentSelector, the class used to represent the classification process
     """
-    comptable["rationale"] = ""
+    comptable["classification_tags"] = ""
     selector = ComponentSelector(tree, comptable, n_echos=n_echos, n_vols=n_vols)
     selector.component_select()
     selector.metadata = collect.get_metadata(selector.component_table)

--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -85,7 +85,7 @@ def manual_selection(comptable, acc=None, rej=None):
     return comptable, metric_metadata
 
 
-def automatic_selection(comptable, n_echos, n_vols, tree="simple"):
+def automatic_selection(comptable, n_echos, n_vols, tree="minimal"):
     """Classify components based on component table and tree type.
 
     Parameters
@@ -108,7 +108,7 @@ def automatic_selection(comptable, n_echos, n_vols, tree="simple"):
     """
     comptable["classification_tags"] = ""
     selector = ComponentSelector(tree, comptable, n_echos=n_echos, n_vols=n_vols)
-    selector.component_select()
+    selector.select()
     selector.metadata = collect.get_metadata(selector.component_table)
 
     # TODO: Eventually return just selector

--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -6,7 +6,7 @@ import numpy as np
 from scipy import stats
 
 from tedana.stats import getfbounds
-from tedana.selection.DecisionTree import DecisionTree
+from tedana.selection.ComponentSelector import ComponentSelector
 from tedana.selection._utils import clean_dataframe
 from tedana.metrics import collect
 
@@ -95,7 +95,7 @@ def automatic_selection(comptable, n_echos, n_vols, tree="simple"):
     n_echos: int
         The number of echoes in this dataset
     tree: str
-        The type of tree to use for the DecisionTree object
+        The type of tree to use for the ComponentSelector object
 
     Returns
     -------
@@ -104,17 +104,17 @@ def automatic_selection(comptable, n_echos, n_vols, tree="simple"):
 
     See Also
     --------
-    DecisionTree, the class used to represent the classification process
+    ComponentSelector, the class used to represent the classification process
     """
     comptable["rationale"] = ""
-    dt = DecisionTree(tree, comptable, n_echos=n_echos, n_vols=n_vols)
-    dt.run()
-    dt.metadata = collect.get_metadata(dt.component_table)
+    selector = ComponentSelector(tree, comptable, n_echos=n_echos, n_vols=n_vols)
+    selector.component_select()
+    selector.metadata = collect.get_metadata(selector.component_table)
 
-    # TODO: Eventually return just dt
+    # TODO: Eventually return just selector
     return (
-        dt.component_table,
-        dt.cross_component_metrics,
-        dt.component_status_table,
-        dt.metadata,
+        selector.component_table,
+        selector.cross_component_metrics,
+        selector.component_status_table,
+        selector.metadata,
     )

--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -108,7 +108,13 @@ def automatic_selection(comptable, n_echos, n_vols, tree="simple"):
     """
     comptable["rationale"] = ""
     dt = DecisionTree(tree, comptable, n_echos=n_echos, n_vols=n_vols)
-    component_table, cross_component_metrics, component_status_table, _ = dt.run()
-    metadata = collect.get_metadata(component_table)
+    dt.run()
+    dt.metadata = collect.get_metadata(dt.component_table)
 
-    return component_table, cross_component_metrics, component_status_table, metadata
+    # TODO: Eventually return just dt
+    return (
+        dt.component_table,
+        dt.cross_component_metrics,
+        dt.component_status_table,
+        dt.metadata,
+    )

--- a/tedana/selection/tedpca.py
+++ b/tedana/selection/tedpca.py
@@ -7,16 +7,16 @@ import numpy as np
 from tedana import utils
 from tedana.stats import getfbounds
 from tedana.metrics import collect
-from tedana.selection._utils import (getelbow_cons, getelbow, clean_dataframe)
+from tedana.selection._utils import getelbow_cons, getelbow, clean_dataframe
 
 LGR = logging.getLogger("GENERAL")
-RepLGR = logging.getLogger('REPORT')
-RefLGR = logging.getLogger('REFERENCES')
+RepLGR = logging.getLogger("REPORT")
+RefLGR = logging.getLogger("REFERENCES")
 
 F_MAX = 500
 
 
-def kundu_tedpca(comptable, n_echos, kdaw=10., rdaw=1., stabilize=False):
+def kundu_tedpca(comptable, n_echos, kdaw=10.0, rdaw=1.0, stabilize=False):
     """
     Select PCA components using Kundu's decision tree approach.
 
@@ -46,84 +46,94 @@ def kundu_tedpca(comptable, n_echos, kdaw=10., rdaw=1., stabilize=False):
         Dictionary with metadata about calculated metrics.
         Each entry corresponds to a column in ``comptable``.
     """
-    LGR.info('Performing PCA component selection with Kundu decision tree')
-    comptable['classification'] = 'accepted'
-    comptable['rationale'] = ''
+    LGR.info("Performing PCA component selection with Kundu decision tree")
+    comptable["classification"] = "accepted"
+    # comptable['rationale'] = ''
 
-    eigenvalue_elbow = getelbow(comptable['normalized variance explained'],
-                                return_val=True)
+    eigenvalue_elbow = getelbow(
+        comptable["normalized variance explained"], return_val=True
+    )
 
-    diff_varex_norm = np.abs(np.diff(comptable['normalized variance explained']))
-    lower_diff_varex_norm = diff_varex_norm[(len(diff_varex_norm) // 2):]
-    varex_norm_thr = np.mean([lower_diff_varex_norm.max(),
-                              diff_varex_norm.min()])
-    varex_norm_min = comptable['normalized variance explained'][
-        (len(diff_varex_norm) // 2) +
-        np.arange(len(lower_diff_varex_norm))[lower_diff_varex_norm >= varex_norm_thr][0] + 1]
-    varex_norm_cum = np.cumsum(comptable['normalized variance explained'])
+    diff_varex_norm = np.abs(np.diff(comptable["normalized variance explained"]))
+    lower_diff_varex_norm = diff_varex_norm[(len(diff_varex_norm) // 2) :]
+    varex_norm_thr = np.mean([lower_diff_varex_norm.max(), diff_varex_norm.min()])
+    varex_norm_min = comptable["normalized variance explained"][
+        (len(diff_varex_norm) // 2)
+        + np.arange(len(lower_diff_varex_norm))[
+            lower_diff_varex_norm >= varex_norm_thr
+        ][0]
+        + 1
+    ]
+    varex_norm_cum = np.cumsum(comptable["normalized variance explained"])
 
     fmin, fmid, fmax = getfbounds(n_echos)
     if int(kdaw) == -1:
-        lim_idx = utils.andb([comptable['kappa'] < fmid,
-                              comptable['kappa'] > fmin]) == 2
-        kappa_lim = comptable.loc[lim_idx, 'kappa'].values
+        lim_idx = (
+            utils.andb([comptable["kappa"] < fmid, comptable["kappa"] > fmin]) == 2
+        )
+        kappa_lim = comptable.loc[lim_idx, "kappa"].values
         kappa_thr = kappa_lim[getelbow(kappa_lim)]
 
-        lim_idx = utils.andb([comptable['rho'] < fmid, comptable['rho'] > fmin]) == 2
-        rho_lim = comptable.loc[lim_idx, 'rho'].values
+        lim_idx = utils.andb([comptable["rho"] < fmid, comptable["rho"] > fmin]) == 2
+        rho_lim = comptable.loc[lim_idx, "rho"].values
         rho_thr = rho_lim[getelbow(rho_lim)]
         stabilize = True
-        LGR.info('kdaw set to -1. Switching TEDPCA algorithm to '
-                 'kundu-stabilize')
+        LGR.info("kdaw set to -1. Switching TEDPCA algorithm to " "kundu-stabilize")
     elif int(rdaw) == -1:
-        lim_idx = utils.andb([comptable['rho'] < fmid, comptable['rho'] > fmin]) == 2
-        rho_lim = comptable.loc[lim_idx, 'rho'].values
+        lim_idx = utils.andb([comptable["rho"] < fmid, comptable["rho"] > fmin]) == 2
+        rho_lim = comptable.loc[lim_idx, "rho"].values
         rho_thr = rho_lim[getelbow(rho_lim)]
     else:
         kappa_thr = np.average(
-            sorted([fmin, (getelbow(comptable['kappa'], return_val=True) / 2), fmid]),
-            weights=[kdaw, 1, 1])
+            sorted([fmin, (getelbow(comptable["kappa"], return_val=True) / 2), fmid]),
+            weights=[kdaw, 1, 1],
+        )
         rho_thr = np.average(
-            sorted([fmin, (getelbow_cons(comptable['rho'], return_val=True) / 2), fmid]),
-            weights=[rdaw, 1, 1])
+            sorted(
+                [fmin, (getelbow_cons(comptable["rho"], return_val=True) / 2), fmid]
+            ),
+            weights=[rdaw, 1, 1],
+        )
 
     # Reject if low Kappa, Rho, and variance explained
-    is_lowk = comptable['kappa'] <= kappa_thr
-    is_lowr = comptable['rho'] <= rho_thr
-    is_lowe = comptable['normalized variance explained'] <= eigenvalue_elbow
+    is_lowk = comptable["kappa"] <= kappa_thr
+    is_lowr = comptable["rho"] <= rho_thr
+    is_lowe = comptable["normalized variance explained"] <= eigenvalue_elbow
     is_lowkre = is_lowk & is_lowr & is_lowe
-    comptable.loc[is_lowkre, 'classification'] = 'rejected'
-    comptable.loc[is_lowkre, 'rationale'] += 'P001;'
+    comptable.loc[is_lowkre, "classification"] = "rejected"
+    comptable.loc[is_lowkre, "rationale"] += "P001;"
 
     # Reject if low variance explained
-    is_lows = comptable['normalized variance explained'] <= varex_norm_min
-    comptable.loc[is_lows, 'classification'] = 'rejected'
-    comptable.loc[is_lows, 'rationale'] += 'P002;'
+    is_lows = comptable["normalized variance explained"] <= varex_norm_min
+    comptable.loc[is_lows, "classification"] = "rejected"
+    comptable.loc[is_lows, "rationale"] += "P002;"
 
     # Reject if Kappa over limit
-    is_fmax1 = comptable['kappa'] == F_MAX
-    comptable.loc[is_fmax1, 'classification'] = 'rejected'
-    comptable.loc[is_fmax1, 'rationale'] += 'P003;'
+    is_fmax1 = comptable["kappa"] == F_MAX
+    comptable.loc[is_fmax1, "classification"] = "rejected"
+    comptable.loc[is_fmax1, "rationale"] += "P003;"
 
     # Reject if Rho over limit
-    is_fmax2 = comptable['rho'] == F_MAX
-    comptable.loc[is_fmax2, 'classification'] = 'rejected'
-    comptable.loc[is_fmax2, 'rationale'] += 'P004;'
+    is_fmax2 = comptable["rho"] == F_MAX
+    comptable.loc[is_fmax2, "classification"] = "rejected"
+    comptable.loc[is_fmax2, "rationale"] += "P004;"
 
     if stabilize:
         temp7 = varex_norm_cum >= 0.95
-        comptable.loc[temp7, 'classification'] = 'rejected'
-        comptable.loc[temp7, 'rationale'] += 'P005;'
-        under_fmin1 = comptable['kappa'] <= fmin
-        comptable.loc[under_fmin1, 'classification'] = 'rejected'
-        comptable.loc[under_fmin1, 'rationale'] += 'P006;'
-        under_fmin2 = comptable['rho'] <= fmin
-        comptable.loc[under_fmin2, 'classification'] = 'rejected'
-        comptable.loc[under_fmin2, 'rationale'] += 'P007;'
+        comptable.loc[temp7, "classification"] = "rejected"
+        comptable.loc[temp7, "rationale"] += "P005;"
+        under_fmin1 = comptable["kappa"] <= fmin
+        comptable.loc[under_fmin1, "classification"] = "rejected"
+        comptable.loc[under_fmin1, "rationale"] += "P006;"
+        under_fmin2 = comptable["rho"] <= fmin
+        comptable.loc[under_fmin2, "classification"] = "rejected"
+        comptable.loc[under_fmin2, "rationale"] += "P007;"
 
-    n_components = comptable.loc[comptable['classification'] == 'accepted'].shape[0]
-    LGR.info('Selected {0} components with Kappa threshold: {1:.02f}, Rho '
-             'threshold: {2:.02f}'.format(n_components, kappa_thr, rho_thr))
+    n_components = comptable.loc[comptable["classification"] == "accepted"].shape[0]
+    LGR.info(
+        "Selected {0} components with Kappa threshold: {1:.02f}, Rho "
+        "threshold: {2:.02f}".format(n_components, kappa_thr, rho_thr)
+    )
 
     # Move decision columns to end
     comptable = clean_dataframe(comptable)

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -17,15 +17,28 @@ from scipy import stats
 from threadpoolctl import threadpool_limits
 from nilearn.masking import compute_epi_mask
 
-from tedana import (decay, combine, decomposition, io, metrics,
-                    reporting, selection, utils, __version__)
+from tedana import (
+    decay,
+    combine,
+    decomposition,
+    io,
+    metrics,
+    reporting,
+    selection,
+    utils,
+    __version__,
+)
 import tedana.gscontrol as gsc
 from tedana.stats import computefeats2
-from tedana.workflows.parser_utils import is_valid_file, check_tedpca_value, ContextFilter
+from tedana.workflows.parser_utils import (
+    is_valid_file,
+    check_tedpca_value,
+    ContextFilter,
+)
 
 LGR = logging.getLogger("GENERAL")
-RepLGR = logging.getLogger('REPORT')
-RefLGR = logging.getLogger('REFERENCES')
+RepLGR = logging.getLogger("REPORT")
+RefLGR = logging.getLogger("REFERENCES")
 
 
 def _get_parser():
@@ -37,238 +50,334 @@ def _get_parser():
     parser.parse_args() : argparse dict
     """
     from ..info import __version__
-    verstr = 'tedana v{}'.format(__version__)
+
+    verstr = "tedana v{}".format(__version__)
     parser = argparse.ArgumentParser()
     # Argument parser follow templtate provided by RalphyZ
     # https://stackoverflow.com/a/43456577
     optional = parser._action_groups.pop()
-    required = parser.add_argument_group('Required Arguments')
-    required.add_argument('-d',
-                          dest='data',
-                          nargs='+',
-                          metavar='FILE',
-                          type=lambda x: is_valid_file(parser, x),
-                          help=('Multi-echo dataset for analysis. May be a '
-                                'single file with spatially concatenated data '
-                                'or a set of echo-specific files, in the same '
-                                'order as the TEs are listed in the -e '
-                                'argument.'),
-                          required=True)
-    required.add_argument('-e',
-                          dest='tes',
-                          nargs='+',
-                          metavar='TE',
-                          type=float,
-                          help='Echo times (in ms). E.g., 15.0 39.0 63.0',
-                          required=True)
-    optional.add_argument('--out-dir',
-                          dest='out_dir',
-                          type=str,
-                          metavar='PATH',
-                          help='Output directory.',
-                          default='.')
-    optional.add_argument('--mask',
-                          dest='mask',
-                          metavar='FILE',
-                          type=lambda x: is_valid_file(parser, x),
-                          help=("Binary mask of voxels to include in TE "
-                                "Dependent ANAlysis. Must be in the same "
-                                "space as `data`. If an explicit mask is not "
-                                "provided, then Nilearn's compute_epi_mask "
-                                "function will be used to derive a mask "
-                                "from the first echo's data."),
-                          default=None)
-    optional.add_argument('--prefix',
-                          dest='prefix',
-                          type=str,
-                          help="Prefix for filenames generated.",
-                          default='')
-    optional.add_argument('--convention',
-                          dest='convention',
-                          action='store',
-                          choices=['orig', 'bids'],
-                          help=("Filenaming convention. bids will use "
-                                "the latest BIDS derivatives version."),
-                          default='bids')
-    optional.add_argument('--fittype',
-                          dest='fittype',
-                          action='store',
-                          choices=['loglin', 'curvefit'],
-                          help=('Desired T2*/S0 fitting method. '
-                                '"loglin" means that a linear model is fit '
-                                'to the log of the data. '
-                                '"curvefit" means that a more computationally '
-                                'demanding monoexponential model is fit '
-                                'to the raw data. '
-                                'Default is "loglin".'),
-                          default='loglin')
-    optional.add_argument('--combmode',
-                          dest='combmode',
-                          action='store',
-                          choices=['t2s'],
-                          help=('Combination scheme for TEs: '
-                                't2s (Posse 1999, default)'),
-                          default='t2s')
-    optional.add_argument('--tedpca',
-                          dest='tedpca',
-                          type=check_tedpca_value,
-                          help=('Method with which to select components in TEDPCA. '
-                                'PCA decomposition with the mdl, kic and aic options '
-                                'is based on a Moving Average (stationary Gaussian) '
-                                'process and are ordered from most to least aggressive. '
-                                "Users may also provide a float from 0 to 1, "
-                                "in which case components will be selected based on the "
-                                "cumulative variance explained. "
-                                "Default='mdl'."),
-                          default='mdl')
-    optional.add_argument('--tree',
-                          dest='tree',
-                          help=('Decision tree to use. You may use a '
-                                'packaged tree (kundu, minimal) or supply a JSON '
-                                'file which matches the decision tree file '
-                                'specification.'),
-                          default='kundu')
-    optional.add_argument('--seed',
-                          dest='fixed_seed',
-                          metavar='INT',
-                          type=int,
-                          help=('Value used for random initialization of ICA '
-                                'algorithm. Set to an integer value for '
-                                'reproducible ICA results. Set to -1 for '
-                                'varying results across ICA calls. '
-                                'Default=42.'),
-                          default=42)
-    optional.add_argument('--maxit',
-                          dest='maxit',
-                          metavar='INT',
-                          type=int,
-                          help=('Maximum number of iterations for ICA.'),
-                          default=500)
-    optional.add_argument('--maxrestart',
-                          dest='maxrestart',
-                          metavar='INT',
-                          type=int,
-                          help=('Maximum number of attempts for ICA. If ICA '
-                                'fails to converge, the fixed seed will be '
-                                'updated and ICA will be run again. If '
-                                'convergence is achieved before maxrestart '
-                                'attempts, ICA will finish early.'),
-                          default=10)
-    optional.add_argument('--tedort',
-                          dest='tedort',
-                          action='store_true',
-                          help=('Orthogonalize rejected components w.r.t. '
-                                'accepted components prior to denoising.'),
-                          default=False)
-    optional.add_argument('--gscontrol',
-                          dest='gscontrol',
-                          required=False,
-                          action='store',
-                          nargs='+',
-                          help=('Perform additional denoising to remove '
-                                'spatially diffuse noise. Default is None. '
-                                'This argument can be single value or a space '
-                                'delimited list'),
-                          choices=['mir', 'gsr'],
-                          default=None)
-    optional.add_argument('--no-reports',
-                          dest='no_reports',
-                          action='store_true',
-                          help=('Creates a figures folder with static component '
-                                'maps, timecourse plots and other diagnostic '
-                                'images and displays these in an interactive '
-                                'reporting framework'),
-                          default=False)
-    optional.add_argument('--png-cmap',
-                          dest='png_cmap',
-                          type=str,
-                          help='Colormap for figures',
-                          default='coolwarm')
-    optional.add_argument('--verbose',
-                          dest='verbose',
-                          action='store_true',
-                          help='Generate intermediate and additional files.',
-                          default=False)
-    optional.add_argument('--lowmem',
-                          dest='low_mem',
-                          action='store_true',
-                          help=('Enables low-memory processing, including the '
-                                'use of IncrementalPCA. May increase workflow '
-                                'duration.'),
-                          default=False)
-    optional.add_argument('--n-threads',
-                          dest='n_threads',
-                          type=int,
-                          action='store',
-                          help=('Number of threads to use. Used by '
-                                'threadpoolctl to set the parameter outside '
-                                'of the workflow function. Higher numbers of '
-                                'threads tend to slow down performance on '
-                                'typical datasets. Default is 1.'),
-                          default=1)
-    optional.add_argument('--debug',
-                          dest='debug',
-                          action='store_true',
-                          help=('Logs in the terminal will have increased '
-                                'verbosity, and will also be written into '
-                                'a .tsv file in the output directory.'),
-                          default=False)
-    optional.add_argument('--quiet',
-                          dest='quiet',
-                          help=argparse.SUPPRESS,
-                          action='store_true',
-                          default=False)
-    optional.add_argument('-v', '--version', action='version', version=verstr)
+    required = parser.add_argument_group("Required Arguments")
+    required.add_argument(
+        "-d",
+        dest="data",
+        nargs="+",
+        metavar="FILE",
+        type=lambda x: is_valid_file(parser, x),
+        help=(
+            "Multi-echo dataset for analysis. May be a "
+            "single file with spatially concatenated data "
+            "or a set of echo-specific files, in the same "
+            "order as the TEs are listed in the -e "
+            "argument."
+        ),
+        required=True,
+    )
+    required.add_argument(
+        "-e",
+        dest="tes",
+        nargs="+",
+        metavar="TE",
+        type=float,
+        help="Echo times (in ms). E.g., 15.0 39.0 63.0",
+        required=True,
+    )
+    optional.add_argument(
+        "--out-dir",
+        dest="out_dir",
+        type=str,
+        metavar="PATH",
+        help="Output directory.",
+        default=".",
+    )
+    optional.add_argument(
+        "--mask",
+        dest="mask",
+        metavar="FILE",
+        type=lambda x: is_valid_file(parser, x),
+        help=(
+            "Binary mask of voxels to include in TE "
+            "Dependent ANAlysis. Must be in the same "
+            "space as `data`. If an explicit mask is not "
+            "provided, then Nilearn's compute_epi_mask "
+            "function will be used to derive a mask "
+            "from the first echo's data."
+        ),
+        default=None,
+    )
+    optional.add_argument(
+        "--prefix",
+        dest="prefix",
+        type=str,
+        help="Prefix for filenames generated.",
+        default="",
+    )
+    optional.add_argument(
+        "--convention",
+        dest="convention",
+        action="store",
+        choices=["orig", "bids"],
+        help=(
+            "Filenaming convention. bids will use "
+            "the latest BIDS derivatives version."
+        ),
+        default="bids",
+    )
+    optional.add_argument(
+        "--fittype",
+        dest="fittype",
+        action="store",
+        choices=["loglin", "curvefit"],
+        help=(
+            "Desired T2*/S0 fitting method. "
+            '"loglin" means that a linear model is fit '
+            "to the log of the data. "
+            '"curvefit" means that a more computationally '
+            "demanding monoexponential model is fit "
+            "to the raw data. "
+            'Default is "loglin".'
+        ),
+        default="loglin",
+    )
+    optional.add_argument(
+        "--combmode",
+        dest="combmode",
+        action="store",
+        choices=["t2s"],
+        help=("Combination scheme for TEs: " "t2s (Posse 1999, default)"),
+        default="t2s",
+    )
+    optional.add_argument(
+        "--tedpca",
+        dest="tedpca",
+        type=check_tedpca_value,
+        help=(
+            "Method with which to select components in TEDPCA. "
+            "PCA decomposition with the mdl, kic and aic options "
+            "is based on a Moving Average (stationary Gaussian) "
+            "process and are ordered from most to least aggressive. "
+            "Users may also provide a float from 0 to 1, "
+            "in which case components will be selected based on the "
+            "cumulative variance explained. "
+            "Default='mdl'."
+        ),
+        default="mdl",
+    )
+    optional.add_argument(
+        "--tree",
+        dest="tree",
+        help=(
+            "Decision tree to use. You may use a "
+            "packaged tree (kundu, minimal) or supply a JSON "
+            "file which matches the decision tree file "
+            "specification."
+        ),
+        default="kundu",
+    )
+    optional.add_argument(
+        "--seed",
+        dest="fixed_seed",
+        metavar="INT",
+        type=int,
+        help=(
+            "Value used for random initialization of ICA "
+            "algorithm. Set to an integer value for "
+            "reproducible ICA results. Set to -1 for "
+            "varying results across ICA calls. "
+            "Default=42."
+        ),
+        default=42,
+    )
+    optional.add_argument(
+        "--maxit",
+        dest="maxit",
+        metavar="INT",
+        type=int,
+        help=("Maximum number of iterations for ICA."),
+        default=500,
+    )
+    optional.add_argument(
+        "--maxrestart",
+        dest="maxrestart",
+        metavar="INT",
+        type=int,
+        help=(
+            "Maximum number of attempts for ICA. If ICA "
+            "fails to converge, the fixed seed will be "
+            "updated and ICA will be run again. If "
+            "convergence is achieved before maxrestart "
+            "attempts, ICA will finish early."
+        ),
+        default=10,
+    )
+    optional.add_argument(
+        "--tedort",
+        dest="tedort",
+        action="store_true",
+        help=(
+            "Orthogonalize rejected components w.r.t. "
+            "accepted components prior to denoising."
+        ),
+        default=False,
+    )
+    optional.add_argument(
+        "--gscontrol",
+        dest="gscontrol",
+        required=False,
+        action="store",
+        nargs="+",
+        help=(
+            "Perform additional denoising to remove "
+            "spatially diffuse noise. Default is None. "
+            "This argument can be single value or a space "
+            "delimited list"
+        ),
+        choices=["mir", "gsr"],
+        default=None,
+    )
+    optional.add_argument(
+        "--no-reports",
+        dest="no_reports",
+        action="store_true",
+        help=(
+            "Creates a figures folder with static component "
+            "maps, timecourse plots and other diagnostic "
+            "images and displays these in an interactive "
+            "reporting framework"
+        ),
+        default=False,
+    )
+    optional.add_argument(
+        "--png-cmap",
+        dest="png_cmap",
+        type=str,
+        help="Colormap for figures",
+        default="coolwarm",
+    )
+    optional.add_argument(
+        "--verbose",
+        dest="verbose",
+        action="store_true",
+        help="Generate intermediate and additional files.",
+        default=False,
+    )
+    optional.add_argument(
+        "--lowmem",
+        dest="low_mem",
+        action="store_true",
+        help=(
+            "Enables low-memory processing, including the "
+            "use of IncrementalPCA. May increase workflow "
+            "duration."
+        ),
+        default=False,
+    )
+    optional.add_argument(
+        "--n-threads",
+        dest="n_threads",
+        type=int,
+        action="store",
+        help=(
+            "Number of threads to use. Used by "
+            "threadpoolctl to set the parameter outside "
+            "of the workflow function. Higher numbers of "
+            "threads tend to slow down performance on "
+            "typical datasets. Default is 1."
+        ),
+        default=1,
+    )
+    optional.add_argument(
+        "--debug",
+        dest="debug",
+        action="store_true",
+        help=(
+            "Logs in the terminal will have increased "
+            "verbosity, and will also be written into "
+            "a .tsv file in the output directory."
+        ),
+        default=False,
+    )
+    optional.add_argument(
+        "--quiet",
+        dest="quiet",
+        help=argparse.SUPPRESS,
+        action="store_true",
+        default=False,
+    )
+    optional.add_argument("-v", "--version", action="version", version=verstr)
     parser._action_groups.append(optional)
 
-    rerungrp = parser.add_argument_group('Arguments for Rerunning the Workflow')
-    rerungrp.add_argument('--t2smap',
-                          dest='t2smap',
-                          metavar='FILE',
-                          type=lambda x: is_valid_file(parser, x),
-                          help=('Precalculated T2* map in the same space as '
-                                'the input data.'),
-                          default=None)
-    rerungrp.add_argument('--mix',
-                          dest='mixm',
-                          metavar='FILE',
-                          type=lambda x: is_valid_file(parser, x),
-                          help=('File containing mixing matrix. If not '
-                                'provided, ME-PCA & ME-ICA is done.'),
-                          default=None)
-    rerungrp.add_argument('--ctab',
-                          dest='ctab',
-                          metavar='FILE',
-                          type=lambda x: is_valid_file(parser, x),
-                          help=(
-                              'File containing a component table from which '
-                              'to extract pre-computed classifications. '
-                              "Requires --mix."
-                          ),
-                          default=None)
-    rerungrp.add_argument('--manacc',
-                          dest='manacc',
-                          metavar='INT',
-                          type=int,
-                          nargs='+',
-                          help=(
-                              'List of manually accepted components. '
-                              "Requires --ctab and --mix."
-                          ),
-                          default=None)
+    rerungrp = parser.add_argument_group("Arguments for Rerunning the Workflow")
+    rerungrp.add_argument(
+        "--t2smap",
+        dest="t2smap",
+        metavar="FILE",
+        type=lambda x: is_valid_file(parser, x),
+        help=("Precalculated T2* map in the same space as " "the input data."),
+        default=None,
+    )
+    rerungrp.add_argument(
+        "--mix",
+        dest="mixm",
+        metavar="FILE",
+        type=lambda x: is_valid_file(parser, x),
+        help=(
+            "File containing mixing matrix. If not "
+            "provided, ME-PCA & ME-ICA is done."
+        ),
+        default=None,
+    )
+    rerungrp.add_argument(
+        "--ctab",
+        dest="ctab",
+        metavar="FILE",
+        type=lambda x: is_valid_file(parser, x),
+        help=(
+            "File containing a component table from which "
+            "to extract pre-computed classifications. "
+            "Requires --mix."
+        ),
+        default=None,
+    )
+    rerungrp.add_argument(
+        "--manacc",
+        dest="manacc",
+        metavar="INT",
+        type=int,
+        nargs="+",
+        help=("List of manually accepted components. " "Requires --ctab and --mix."),
+        default=None,
+    )
 
     return parser
 
 
-def tedana_workflow(data, tes, out_dir='.', mask=None,
-                    convention='bids', prefix='',
-                    fittype='loglin', combmode='t2s', tedpca='mdl',
-                    tree='kundu',
-                    fixed_seed=42, maxit=500, maxrestart=10,
-                    tedort=False, gscontrol=None,
-                    no_reports=False, png_cmap='coolwarm',
-                    verbose=False, low_mem=False, debug=False, quiet=False,
-                    t2smap=None, mixm=None, ctab=None, manacc=None):
+def tedana_workflow(
+    data,
+    tes,
+    out_dir=".",
+    mask=None,
+    convention="bids",
+    prefix="",
+    fittype="loglin",
+    combmode="t2s",
+    tedpca="mdl",
+    tree="kundu",
+    fixed_seed=42,
+    maxit=500,
+    maxrestart=10,
+    tedort=False,
+    gscontrol=None,
+    no_reports=False,
+    png_cmap="coolwarm",
+    verbose=False,
+    low_mem=False,
+    debug=False,
+    quiet=False,
+    t2smap=None,
+    mixm=None,
+    ctab=None,
+    manacc=None,
+):
     """
     Run the "canonical" TE-Dependent ANAlysis workflow.
 
@@ -360,29 +469,30 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
         os.mkdir(out_dir)
 
     # boilerplate
-    basename = 'report'
-    extension = 'txt'
-    repname = op.join(out_dir, (basename + '.' + extension))
-    repex = op.join(out_dir, (basename + '*'))
+    basename = "report"
+    extension = "txt"
+    repname = op.join(out_dir, (basename + "." + extension))
+    repex = op.join(out_dir, (basename + "*"))
     previousreps = glob(repex)
     previousreps.sort(reverse=True)
     for f in previousreps:
         previousparts = op.splitext(f)
-        newname = previousparts[0] + '_old' + previousparts[1]
+        newname = previousparts[0] + "_old" + previousparts[1]
         os.rename(f, newname)
-    refname = op.join(out_dir, '_references.txt')
+    refname = op.join(out_dir, "_references.txt")
 
     # create logfile name
-    basename = 'tedana_'
-    extension = 'tsv'
-    start_time = datetime.datetime.now().strftime('%Y-%m-%dT%H%M%S')
-    logname = op.join(out_dir, (basename + start_time + '.' + extension))
+    basename = "tedana_"
+    extension = "tsv"
+    start_time = datetime.datetime.now().strftime("%Y-%m-%dT%H%M%S")
+    logname = op.join(out_dir, (basename + start_time + "." + extension))
 
     # set logging format
     log_formatter = logging.Formatter(
-        '%(asctime)s\t%(name)-12s\t%(levelname)-8s\t%(message)s',
-        datefmt='%Y-%m-%dT%H:%M:%S')
-    text_formatter = logging.Formatter('%(message)s')
+        "%(asctime)s\t%(name)-12s\t%(levelname)-8s\t%(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+    text_formatter = logging.Formatter("%(message)s")
 
     # set up logging file and open it for writing
     log_handler = logging.FileHandler(logname)
@@ -412,7 +522,7 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
     RefLGR.setLevel(logging.INFO)
     RefLGR.addHandler(ref_handler)
 
-    LGR.info('Using output directory: {}'.format(out_dir))
+    LGR.info("Using output directory: {}".format(out_dir))
 
     # ensure tes are in appropriate format
     tes = [float(te) for te in tes]
@@ -425,7 +535,7 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
     # Check value of tedpca *if* it is a float
     tedpca = check_tedpca_value(tedpca, is_parser=False)
 
-    LGR.info('Loading input data: {}'.format([f for f in data]))
+    LGR.info("Loading input data: {}".format([f for f in data]))
     catd, ref_img = io.load_data(data, n_echos=n_echos)
     io_generator = io.OutputGenerator(
         ref_img,
@@ -437,18 +547,20 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
     )
 
     n_samp, n_echos, n_vols = catd.shape
-    LGR.debug('Resulting data shape: {}'.format(catd.shape))
+    LGR.debug("Resulting data shape: {}".format(catd.shape))
 
     # check if TR is 0
     img_t_r = io_generator.reference_img.header.get_zooms()[-1]
     if img_t_r == 0:
-        raise IOError('Dataset has a TR of 0. This indicates incorrect'
-                      ' header information. To correct this, we recommend'
-                      ' using this snippet:'
-                      '\n'
-                      'https://gist.github.com/jbteves/032c87aeb080dd8de8861cb151bff5d6'
-                      '\n'
-                      'to correct your TR to the value it should be.')
+        raise IOError(
+            "Dataset has a TR of 0. This indicates incorrect"
+            " header information. To correct this, we recommend"
+            " using this snippet:"
+            "\n"
+            "https://gist.github.com/jbteves/032c87aeb080dd8de8861cb151bff5d6"
+            "\n"
+            "to correct your TR to the value it should be."
+        )
 
     if mixm is not None and op.isfile(mixm):
         mixm = op.abspath(mixm)
@@ -481,7 +593,7 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
         manacc = [int(m) for m in manacc]
 
     if t2smap is not None and op.isfile(t2smap):
-        t2smap_file = io_generator.get_name('t2star img')
+        t2smap_file = io_generator.get_name("t2star img")
         t2smap = op.abspath(t2smap)
         # Allow users to re-run on same folder
         if t2smap != t2smap_file:
@@ -492,72 +604,86 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
     RepLGR.info("TE-dependence analysis was performed on input data.")
     if mask and not t2smap:
         # TODO: add affine check
-        LGR.info('Using user-defined mask')
+        LGR.info("Using user-defined mask")
         RepLGR.info("A user-defined mask was applied to the data.")
     elif t2smap and not mask:
-        LGR.info('Using user-defined T2* map to generate mask')
+        LGR.info("Using user-defined T2* map to generate mask")
         t2s_limited_sec = utils.load_image(t2smap)
         t2s_limited = utils.sec2millisec(t2s_limited_sec)
         t2s_full = t2s_limited.copy()
         mask = (t2s_limited != 0).astype(int)
     elif t2smap and mask:
-        LGR.info('Combining user-defined mask and T2* map to generate mask')
+        LGR.info("Combining user-defined mask and T2* map to generate mask")
         t2s_limited_sec = utils.load_image(t2smap)
         t2s_limited = utils.sec2millisec(t2s_limited_sec)
         t2s_full = t2s_limited.copy()
         mask = utils.load_image(mask)
         mask[t2s_limited == 0] = 0  # reduce mask based on T2* map
     else:
-        LGR.info('Computing EPI mask from first echo')
+        LGR.info("Computing EPI mask from first echo")
         first_echo_img = io.new_nii_like(io_generator.reference_img, catd[:, 0, :])
         mask = compute_epi_mask(first_echo_img)
-        RepLGR.info("An initial mask was generated from the first echo using "
-                    "nilearn's compute_epi_mask function.")
+        RepLGR.info(
+            "An initial mask was generated from the first echo using "
+            "nilearn's compute_epi_mask function."
+        )
 
     # Create an adaptive mask with at least 3 good echoes.
     mask, masksum = utils.make_adaptive_mask(catd, mask=mask, getsum=True, threshold=3)
-    LGR.debug('Retaining {}/{} samples'.format(mask.sum(), n_samp))
+    LGR.debug("Retaining {}/{} samples".format(mask.sum(), n_samp))
     io_generator.save_file(masksum, "adaptive mask img")
 
     if t2smap is None:
-        LGR.info('Computing T2* map')
+        LGR.info("Computing T2* map")
         t2s_limited, s0_limited, t2s_full, s0_full = decay.fit_decay(
-            catd, tes, mask, masksum, fittype)
+            catd, tes, mask, masksum, fittype
+        )
 
         # set a hard cap for the T2* map
         # anything that is 10x higher than the 99.5 %ile will be reset to 99.5 %ile
-        cap_t2s = stats.scoreatpercentile(t2s_limited.flatten(), 99.5,
-                                          interpolation_method='lower')
-        LGR.debug('Setting cap on T2* map at {:.5f}s'.format(
-            utils.millisec2sec(cap_t2s)))
+        cap_t2s = stats.scoreatpercentile(
+            t2s_limited.flatten(), 99.5, interpolation_method="lower"
+        )
+        LGR.debug(
+            "Setting cap on T2* map at {:.5f}s".format(utils.millisec2sec(cap_t2s))
+        )
         t2s_limited[t2s_limited > cap_t2s * 10] = cap_t2s
-        io_generator.save_file(utils.millisec2sec(t2s_limited), 't2star img')
-        io_generator.save_file(s0_limited, 's0 img')
+        io_generator.save_file(utils.millisec2sec(t2s_limited), "t2star img")
+        io_generator.save_file(s0_limited, "s0 img")
 
         if verbose:
-            io_generator.save_file(utils.millisec2sec(t2s_full), 'full t2star img')
-            io_generator.save_file(s0_full, 'full s0 img')
+            io_generator.save_file(utils.millisec2sec(t2s_full), "full t2star img")
+            io_generator.save_file(s0_full, "full s0 img")
 
     # optimally combine data
     data_oc = combine.make_optcom(catd, tes, masksum, t2s=t2s_full, combmode=combmode)
 
     # regress out global signal unless explicitly not desired
-    if 'gsr' in gscontrol:
+    if "gsr" in gscontrol:
         catd, data_oc = gsc.gscontrol_raw(catd, data_oc, n_echos, io_generator)
 
-    fout = io_generator.save_file(data_oc, 'combined img')
-    LGR.info('Writing optimally combined data set: {}'.format(fout))
+    fout = io_generator.save_file(data_oc, "combined img")
+    LGR.info("Writing optimally combined data set: {}".format(fout))
 
     if mixm is None:
         # Identify and remove thermal noise from data
-        dd, n_components = decomposition.tedpca(catd, data_oc, combmode, mask,
-                                                masksum, t2s_full, io_generator,
-                                                tes=tes, algorithm=tedpca,
-                                                kdaw=10., rdaw=1.,
-                                                verbose=verbose,
-                                                low_mem=low_mem)
+        dd, n_components = decomposition.tedpca(
+            catd,
+            data_oc,
+            combmode,
+            mask,
+            masksum,
+            t2s_full,
+            io_generator,
+            tes=tes,
+            algorithm=tedpca,
+            kdaw=10.0,
+            rdaw=1.0,
+            verbose=verbose,
+            low_mem=low_mem,
+        )
         if verbose:
-            io_generator.save_file(utils.unmask(dd, mask), 'whitened img')
+            io_generator.save_file(utils.unmask(dd, mask), "whitened img")
 
         # Perform ICA, calculate metrics, and apply decision tree
         # Restart when ICA fails to converge or too few BOLD components found
@@ -566,8 +692,7 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
         seed = fixed_seed
         while keep_restarting:
             mmix, seed = decomposition.tedica(
-                dd, n_components, seed,
-                maxit, maxrestart=(maxrestart - n_restarts)
+                dd, n_components, seed, maxit, maxrestart=(maxrestart - n_restarts)
             )
             seed += 1
             n_restarts = seed - fixed_seed
@@ -575,26 +700,44 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
             # Estimate betas and compute selection metrics for mixing matrix
             # generated from dimensionally reduced data using full data (i.e., data
             # with thermal noise)
-            LGR.info('Making second component selection guess from ICA results')
+            LGR.info("Making second component selection guess from ICA results")
             required_metrics = [
-                'kappa', 'rho', 'countnoise', 'countsigFT2', 'countsigFS0',
-                'dice_FT2', 'dice_FS0', 'signal-noise_t',
-                'variance explained', 'normalized variance explained',
-                'd_table_score'
+                "kappa",
+                "rho",
+                "countnoise",
+                "countsigFT2",
+                "countsigFS0",
+                "dice_FT2",
+                "dice_FS0",
+                "signal-noise_t",
+                "variance explained",
+                "normalized variance explained",
+                "d_table_score",
             ]
             comptable = metrics.collect.generate_metrics(
-                catd, data_oc, mmix, masksum, tes,
-                io_generator, 'ICA',
+                catd,
+                data_oc,
+                mmix,
+                masksum,
+                tes,
+                io_generator,
+                "ICA",
                 metrics=required_metrics,
             )
-            comptable, metric_metadata = selection.automatic_selection(
-                comptable, n_echos, n_vols, tree=tree
-            )
-            n_bold_comps = comptable[comptable.classification == 'accepted'].shape[0]
+            # NOTE: Added cross_component_metrics and component_status_table here, but they are not yet stored anywhere
+            (
+                comptable,
+                cross_component_metrics,
+                component_status_table,
+                metric_metadata,
+            ) = selection.automatic_selection(comptable, n_echos, n_vols, tree=tree)
+            n_bold_comps = comptable[comptable.classification == "accepted"].shape[0]
             if (n_restarts < maxrestart) and (n_bold_comps == 0):
                 LGR.warning("No BOLD components found. Re-attempting ICA.")
-            elif (n_bold_comps == 0):
-                LGR.warning("No BOLD components found, but maximum number of restarts reached.")
+            elif n_bold_comps == 0:
+                LGR.warning(
+                    "No BOLD components found, but maximum number of restarts reached."
+                )
                 keep_restarting = False
             else:
                 keep_restarting = False
@@ -602,32 +745,46 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
             RepLGR.disabled = True  # Disable the report to avoid duplicate text
         RepLGR.disabled = False  # Re-enable the report after the while loop is escaped
     else:
-        LGR.info('Using supplied mixing matrix from ICA')
+        LGR.info("Using supplied mixing matrix from ICA")
         mixing_file = io_generator.get_name("ICA mixing tsv")
         mmix = pd.read_table(mixing_file).values
 
         if ctab is None:
             required_metrics = [
-                'kappa', 'rho', 'countnoise', 'countsigFT2', 'countsigFS0',
-                'dice_FT2', 'dice_FS0', 'signal-noise_t',
-                'variance explained', 'normalized variance explained',
-                'd_table_score'
+                "kappa",
+                "rho",
+                "countnoise",
+                "countsigFT2",
+                "countsigFS0",
+                "dice_FT2",
+                "dice_FS0",
+                "signal-noise_t",
+                "variance explained",
+                "normalized variance explained",
+                "d_table_score",
             ]
             comptable = metrics.collect.generate_metrics(
-                catd, data_oc, mmix, masksum, tes,
-                io_generator, 'ICA',
+                catd,
+                data_oc,
+                mmix,
+                masksum,
+                tes,
+                io_generator,
+                "ICA",
                 metrics=required_metrics,
             )
-            comptable, metric_metadata = selection.automatic_selection(
-                    comptable, n_echos, n_vols, tree=tree
-            )
+            (
+                comptable,
+                cross_component_metrics,
+                component_status_table,
+                metric_metadata,
+            ) = selection.automatic_selection(comptable, n_echos, n_vols, tree=tree)
         else:
             comptable = pd.read_table(ctab)
 
             if manacc is not None:
                 comptable, metric_metadata = selection.manual_selection(
-                    comptable,
-                    acc=manacc
+                    comptable, acc=manacc
                 )
 
     # Write out ICA files.
@@ -635,7 +792,7 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
     mixing_df = pd.DataFrame(data=mmix, columns=comp_names)
     io_generator.save_file(mixing_df, "ICA mixing tsv")
     betas_oc = utils.unmask(computefeats2(data_oc, mmix, mask), mask)
-    io_generator.save_file(betas_oc, 'z-scored ICA components img')
+    io_generator.save_file(betas_oc, "z-scored ICA components img")
 
     # Save component table and associated json
     io_generator.save_file(comptable, "ICA metrics tsv")
@@ -656,38 +813,45 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
     with open(io_generator.get_name("ICA decomposition json"), "w") as fo:
         json.dump(decomp_metadata, fo, sort_keys=True, indent=4)
 
-    if comptable[comptable.classification == 'accepted'].shape[0] == 0:
-        LGR.warning('No BOLD components detected! Please check data and '
-                    'results!')
+    if comptable[comptable.classification == "accepted"].shape[0] == 0:
+        LGR.warning("No BOLD components detected! Please check data and " "results!")
 
     mmix_orig = mmix.copy()
     if tedort:
-        acc_idx = comptable.loc[~comptable.classification.str.
-                                contains('rejected')].index.values
-        rej_idx = comptable.loc[comptable.classification.str.contains(
-            'rejected')].index.values
+        acc_idx = comptable.loc[
+            ~comptable.classification.str.contains("rejected")
+        ].index.values
+        rej_idx = comptable.loc[
+            comptable.classification.str.contains("rejected")
+        ].index.values
         acc_ts = mmix[:, acc_idx]
         rej_ts = mmix[:, rej_idx]
         betas = np.linalg.lstsq(acc_ts, rej_ts, rcond=None)[0]
         pred_rej_ts = np.dot(acc_ts, betas)
         resid = rej_ts - pred_rej_ts
         mmix[:, rej_idx] = resid
-        comp_names = [io.add_decomp_prefix(comp, prefix='ica', max_value=comptable.index.max())
-                      for comp in comptable.index.values]
+        comp_names = [
+            io.add_decomp_prefix(comp, prefix="ica", max_value=comptable.index.max())
+            for comp in comptable.index.values
+        ]
         mixing_df = pd.DataFrame(data=mmix, columns=comp_names)
         io_generator.save_file(mixing_df, "ICA orthogonalized mixing tsv")
-        RepLGR.info("Rejected components' time series were then "
-                    "orthogonalized with respect to accepted components' time "
-                    "series.")
+        RepLGR.info(
+            "Rejected components' time series were then "
+            "orthogonalized with respect to accepted components' time "
+            "series."
+        )
 
-    io.writeresults(data_oc,
-                    mask=mask,
-                    comptable=comptable,
-                    mmix=mmix,
-                    n_vols=n_vols,
-                    io_generator=io_generator)
+    io.writeresults(
+        data_oc,
+        mask=mask,
+        comptable=comptable,
+        mmix=mmix,
+        n_vols=n_vols,
+        io_generator=io_generator,
+    )
 
-    if 'mir' in gscontrol:
+    if "mir" in gscontrol:
         gsc.minimum_image_regression(data_oc, mmix, mask, comptable, io_generator)
 
     if verbose:
@@ -706,56 +870,76 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
                     "A denoising pipeline for the identification and removal "
                     "of non-BOLD noise from multi-echo fMRI data."
                 ),
-                "CodeURL": "https://github.com/ME-ICA/tedana"
+                "CodeURL": "https://github.com/ME-ICA/tedana",
             }
-        ]
+        ],
     }
     with open(io_generator.get_name("data description json"), "w") as fo:
         json.dump(derivative_metadata, fo, sort_keys=True, indent=4)
 
-    LGR.info('Workflow completed')
+    LGR.info("Workflow completed")
 
-    RepLGR.info("This workflow used numpy (Van Der Walt, Colbert, & "
-                "Varoquaux, 2011), scipy (Jones et al., 2001), pandas "
-                "(McKinney, 2010), scikit-learn (Pedregosa et al., 2011), "
-                "nilearn, and nibabel (Brett et al., 2019).")
-    RefLGR.info("Van Der Walt, S., Colbert, S. C., & Varoquaux, G. (2011). The "
-                "NumPy array: a structure for efficient numerical computation. "
-                "Computing in Science & Engineering, 13(2), 22.")
-    RefLGR.info("Jones E, Oliphant E, Peterson P, et al. SciPy: Open Source "
-                "Scientific Tools for Python, 2001-, http://www.scipy.org/")
-    RefLGR.info("McKinney, W. (2010, June). Data structures for statistical "
-                "computing in python. In Proceedings of the 9th Python in "
-                "Science Conference (Vol. 445, pp. 51-56).")
-    RefLGR.info("Pedregosa, F., Varoquaux, G., Gramfort, A., Michel, V., "
-                "Thirion, B., Grisel, O., ... & Vanderplas, J. (2011). "
-                "Scikit-learn: Machine learning in Python. Journal of machine "
-                "learning research, 12(Oct), 2825-2830.")
-    RefLGR.info("Brett, M., Markiewicz, C. J., Hanke, M., Côté, M.-A., "
-                "Cipollini, B., McCarthy, P., … freec84. (2019, May 28). "
-                "nipy/nibabel. Zenodo. http://doi.org/10.5281/zenodo.3233118")
+    RepLGR.info(
+        "This workflow used numpy (Van Der Walt, Colbert, & "
+        "Varoquaux, 2011), scipy (Jones et al., 2001), pandas "
+        "(McKinney, 2010), scikit-learn (Pedregosa et al., 2011), "
+        "nilearn, and nibabel (Brett et al., 2019)."
+    )
+    RefLGR.info(
+        "Van Der Walt, S., Colbert, S. C., & Varoquaux, G. (2011). The "
+        "NumPy array: a structure for efficient numerical computation. "
+        "Computing in Science & Engineering, 13(2), 22."
+    )
+    RefLGR.info(
+        "Jones E, Oliphant E, Peterson P, et al. SciPy: Open Source "
+        "Scientific Tools for Python, 2001-, http://www.scipy.org/"
+    )
+    RefLGR.info(
+        "McKinney, W. (2010, June). Data structures for statistical "
+        "computing in python. In Proceedings of the 9th Python in "
+        "Science Conference (Vol. 445, pp. 51-56)."
+    )
+    RefLGR.info(
+        "Pedregosa, F., Varoquaux, G., Gramfort, A., Michel, V., "
+        "Thirion, B., Grisel, O., ... & Vanderplas, J. (2011). "
+        "Scikit-learn: Machine learning in Python. Journal of machine "
+        "learning research, 12(Oct), 2825-2830."
+    )
+    RefLGR.info(
+        "Brett, M., Markiewicz, C. J., Hanke, M., Côté, M.-A., "
+        "Cipollini, B., McCarthy, P., … freec84. (2019, May 28). "
+        "nipy/nibabel. Zenodo. http://doi.org/10.5281/zenodo.3233118"
+    )
 
-    RepLGR.info("This workflow also used the Dice similarity index "
-                "(Dice, 1945; Sørensen, 1948).")
-    RefLGR.info("Dice, L. R. (1945). Measures of the amount of ecologic "
-                "association between species. Ecology, 26(3), 297-302.")
-    RefLGR.info("Sørensen, T. J. (1948). A method of establishing groups of "
-                "equal amplitude in plant sociology based on similarity of "
-                "species content and its application to analyses of the "
-                "vegetation on Danish commons. I kommission hos E. Munksgaard.")
+    RepLGR.info(
+        "This workflow also used the Dice similarity index "
+        "(Dice, 1945; Sørensen, 1948)."
+    )
+    RefLGR.info(
+        "Dice, L. R. (1945). Measures of the amount of ecologic "
+        "association between species. Ecology, 26(3), 297-302."
+    )
+    RefLGR.info(
+        "Sørensen, T. J. (1948). A method of establishing groups of "
+        "equal amplitude in plant sociology based on similarity of "
+        "species content and its application to analyses of the "
+        "vegetation on Danish commons. I kommission hos E. Munksgaard."
+    )
 
-    with open(repname, 'r') as fo:
+    with open(repname, "r") as fo:
         report = [line.rstrip() for line in fo.readlines()]
-        report = ' '.join(report)
-    with open(refname, 'r') as fo:
+        report = " ".join(report)
+    with open(refname, "r") as fo:
         reference_list = sorted(list(set(fo.readlines())))
-        references = '\n'.join(reference_list)
-    report += '\n\nReferences:\n\n' + references
-    with open(repname, 'w') as fo:
+        references = "\n".join(reference_list)
+    report += "\n\nReferences:\n\n" + references
+    with open(repname, "w") as fo:
         fo.write(report)
 
     if not no_reports:
-        LGR.info('Making figures folder with static component maps and timecourse plots.')
+        LGR.info(
+            "Making figures folder with static component maps and timecourse plots."
+        )
 
         dn_ts, hikts, lowkts = io.denoise_ts(data_oc, mmix, mask, comptable)
 
@@ -778,11 +962,13 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
         )
 
         if sys.version_info.major == 3 and sys.version_info.minor < 6:
-            warn_msg = ("Reports requested but Python version is less than "
-                        "3.6.0. Dynamic reports will not be generated.")
+            warn_msg = (
+                "Reports requested but Python version is less than "
+                "3.6.0. Dynamic reports will not be generated."
+            )
             LGR.warn(warn_msg)
         else:
-            LGR.info('Generating dynamic report')
+            LGR.info("Generating dynamic report")
             reporting.generate_report(io_generator, tr=img_t_r)
 
     log_handler.close()
@@ -795,18 +981,18 @@ def tedana_workflow(data, tes, out_dir='.', mask=None,
             local_logger.removeHandler(handler)
     os.remove(refname)
 
-    LGR.info('Workflow completed')
+    LGR.info("Workflow completed")
 
 
 def _main(argv=None):
     """Tedana entry point"""
     options = _get_parser().parse_args(argv)
     kwargs = vars(options)
-    n_threads = kwargs.pop('n_threads')
+    n_threads = kwargs.pop("n_threads")
     n_threads = None if n_threads == -1 else n_threads
     with threadpool_limits(limits=n_threads, user_api=None):
         tedana_workflow(**kwargs)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     _main()


### PR DESCRIPTION
To do:

- [x] Remove self.config, make log contents or make attributes in self. Add warning for unused keys in the config
- [x] Move nodes into class
- [x] Change `DecisionTree` to `ComponentSelector` and `def run` to `def component_select()`
- [x] Change `DT_class` to `selector`
- [x] Update dnode_outputs within the class and move used_metrics and decision_node_idx into the class
- [x] def selectcomps2use(…): # TODO: add number indexing (instead of ugly message)
- [x] Add nodes for calculating metrics based on values across components
- [x] Create separate nodes for calculating kappa and rho
- [x] are_only_necessary_metrics_used is fixed to output warnings if pre-declared necessary metrics don't match used_metrics
- [x] Implement the use of classification tags
- [x] Make a better doc string for the class
- [x] Write building_decision_trees.rst to summarize the various parts of understanding and buidlgin a decision tree in one place
- [x] Add a warning if the final classifications include something besides accepted or rejected
- [x] Fix docstrings for selection_nodes.py functions
- [x] If it's relatively painless, try to figure out how to get rid of the `rationale` column in the component table
- [x] change_comptable_classifications is better modularized and logs a warning if a component is changed away from accepted or rejected
- [x] Fix docstrings in _utils.py
- [x] numTrue and numFalse calculated in change_comptable_classifications rather than having the same code repeated in each function
- [ ] Link building_decision_trees.rst to the rest of the documentation

Changes proposed in this pull request:

- Finish all of the above and get the minimal decision tree fully functional with good-enough documentation

Follow-up PRs for after this is merged into  jbteves:JT_DTM:
1. Write a function to save the contents of `selector` (This might be to part that info into a few different files (to discuss/plan)
2.  Add tests (just for the class & minimal tree) and improve documentation more
3. Take a look at the minimal tree and decide if there are any other places to streamline / remove repetitive code
4. Get the kundu decision tree working. The structural changes is this will involve are:
    - Removing the `previous_x_steps` option and used intermediate classifications instead
    - Separate cross component metric calculations from decision nodes (decide how much I want to separate for functions or metrics that will likely never be used outside of the kundu tree)
5. Clean up what goes to stdout and the logger in this section of the code. Right now there are a few data dumps to the screen, which are great for development, but a mess for anyone else.
6. Consider moving the initialization and running of the class into tedana.py vs tedica.py (might open up other refactoring issues & might be better to do after we make sure JT_DTM is more up-to-date with Main first.
7. manual_selection is in tedica.py and manual_classify is in selection_nodes.py. Code should not be repeated between the two functions. (manual_classify is designed to be accessible without needing a decision tree to run it)
8. Look for functions that don't need to exist outside of the class that can be moved into the class
9. Make sure documentation renders and renders correctly
10. `rationale` and descriptions of rationale are in several places in the documention. Remove all and replace with an explanation of `classification_tags` There is a non-trivial amount of work to update output descriptions based on these changes.
11. For tree validation, add a confirmation that no cross component metrics are re-calculated in more than one node.
12. Add validation to dry run the tree and make sure used metrics match before it's run