### PR TITLE
[skip ci] More ComponentSelector tests

### DIFF
--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from scipy.stats import scoreatpercentile
 from tedana.stats import getfbounds
-from tedana.selection._utils import (
+from tedana.selection.selection_utils import (
     confirm_metrics_exist,
     selectcomps2use,
     log_decision_tree_step,

--- a/tedana/selection/selection_utils.py
+++ b/tedana/selection/selection_utils.py
@@ -48,7 +48,7 @@ def selectcomps2use(selector, decide_comps):
     ----
     TODO: Number indexing should work here, but validator would not currently allow
     numbers to be assigned to a node in the ComponentSelector object. May want to make
-    sure this option is acceissble through the class.
+    sure this option is accessible through the class.
     """
 
     component_table = selector.component_table
@@ -89,8 +89,9 @@ def change_comptable_classifications(
     dont_warn_reclassify=False,
 ):
     """
-    Given information on whether a decision critereon is true or false for each component
-    change or don't change the component classification
+    Calls comptable_classification_changer to change (or not change) component
+    classifications based on whether a decision critereon is true or false for
+    each component
 
     Parameters
     ----------
@@ -579,7 +580,7 @@ def get_extend_factor(n_vols=None, extend_factor=None):
             "extend_factor={}, based on number of fMRI volumes".format(extend_factor)
         )
     else:
-        error_msg = "get_extend_factor need n_vols or extend_factor as an input"
+        error_msg = "get_extend_factor needs n_vols or extend_factor as an input"
         LGR.error(error_msg)
         ValueError(error_msg)
     return extend_factor

--- a/tedana/selection/tedica.py
+++ b/tedana/selection/tedica.py
@@ -7,7 +7,7 @@ from scipy import stats
 
 from tedana.stats import getfbounds
 from tedana.selection.ComponentSelector import ComponentSelector
-from tedana.selection._utils import clean_dataframe
+from tedana.selection.selection_utils import clean_dataframe
 from tedana.metrics import collect
 
 LGR = logging.getLogger("GENERAL")

--- a/tedana/selection/tedpca.py
+++ b/tedana/selection/tedpca.py
@@ -7,7 +7,7 @@ import numpy as np
 from tedana import utils
 from tedana.stats import getfbounds
 from tedana.metrics import collect
-from tedana.selection._utils import getelbow_cons, getelbow, clean_dataframe
+from tedana.selection.selection_utils import getelbow_cons, getelbow, clean_dataframe
 
 LGR = logging.getLogger("GENERAL")
 RepLGR = logging.getLogger("REPORT")

--- a/tedana/tests/test_ComponentSelector.py
+++ b/tedana/tests/test_ComponentSelector.py
@@ -1,5 +1,6 @@
 """Tests for the decision tree modularization"""
 import pytest
+import pandas as pd
 import json, os, glob
 
 from tedana.selection import ComponentSelector
@@ -19,7 +20,8 @@ def dicts_to_test(treechoice):
     ----------
     treechoice: :obj:`str` One of several labels to select which dict to output
         Options are:
-        "valid": A tree that would trigger all warnings, but pass validation
+        "valid": A valid tree without any warnings
+        "warnings": A tree that would trigger all warnings, but pass validation
         "extra_req_param": A tree with an undefined required parameter for a decision node function
         "extra_opt_param": A tree with an undefined optional parameter for a decision node function
         "missing_req_param": A missing required param in a decision node function
@@ -32,17 +34,14 @@ def dicts_to_test(treechoice):
     """
 
     # valid_dict is a simple valid dictionary to test
-    # It includes a few things that should trigger warnings, but not errors.
     valid_dict = {
         "tree_id": "valid_simple_tree",
         "info": "This is a short valid tree",
         "report": "",
         "refs": "",
-        # Warning for an unused key
-        "unused_key": "There can be added keys that are valid, but aren't used",
         "necessary_metrics": ["kappa", "rho"],
-        "intermediate_classifications": ["random1"],
-        "classification_tags": ["Random1"],
+        "intermediate_classifications": ["random1", "random2"],
+        "classification_tags": ["Random1", "Random2"],
         "nodes": [
             {
                 "functionname": "dec_left_op_right",
@@ -72,22 +71,19 @@ def dicts_to_test(treechoice):
                 "kwargs": {
                     "log_extra_info": "random2 if Kappa>Rho",
                     "log_extra_report": "",
-                    # Warning for an non-predefined classification assigned to a component
-                    "tag_ifTrue": "random2notpredefined",
+                    "tag_ifTrue": "random2",
                 },
             },
             {
                 "functionname": "manual_classify",
                 "parameters": {
                     "new_classification": "accepted",
-                    # Warning for an non-predefined classification used to select components to operate on
-                    "decide_comps": "random2notpredefined",
+                    "decide_comps": "random2",
                 },
                 "kwargs": {
                     "log_extra_info": "",
                     "log_extra_report": "",
-                    # Warning for a tag that wasn't predefined
-                    "tag": "Random2_NotPredefined",
+                    "tag": "Random2",
                 },
             },
             {
@@ -106,6 +102,12 @@ def dicts_to_test(treechoice):
     tree = valid_dict
     if treechoice == "valid":
         return tree
+    elif treechoice == "warnings":
+        tree["unused_key"] = "There can be added keys that are valid, but are not used"
+        tree["nodes"][1]["kwargs"]["tag_ifTrue"] = "classification_not_predefined"
+        tree["nodes"][2]["parameters"]["decide_comps"] = "classification_not_predefined"
+        tree["nodes"][2]["kwargs"]["tag"] = "tag_not_predefined"
+
     elif treechoice == "extra_req_param":
         tree["nodes"][0]["parameters"]["nonexistent_req_param"] = True
     elif treechoice == "extra_opt_param":
@@ -120,6 +122,45 @@ def dicts_to_test(treechoice):
         raise Exception(f"{treechoice} is an invalid option for treechoice")
 
     return tree
+
+
+def component_table_to_test(tablechoice):
+    """
+    A default component table to use for various tests
+
+    Parameters
+    ----------
+    tablechoice: :obj:`str`
+        One of several labels to select which component_table to output
+        Options are:
+        "valid": A valid table without any warnings
+        "notDF": A variable that is an int rather than a dataframe
+        "noComponent": A table missing the "Component" column
+    """
+
+    comp_dict = {
+        "Component": [0, 1, 2, 3, 4, 5, 6],
+        "kappa": [100, 90, 80, 70, 60, 50, 40],
+        "rho": [40, 50, 60, 70, 80, 90, 100],
+        "dice_FT2": [0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7],
+        "dice_FS0": [0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4],
+        "countsigFT2": [5000, 5000, 5000, 5000, 5000, 5000, 5000],
+        "countsigFS0": [4000, 4000, 4000, 4000, 4000, 4000, 4000],
+        "variance explained": [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.4],
+        "signal-noise_t": [3000, 3000, 3000, 3000, 3000, 3000, 3000],
+    }
+
+    component_table = pd.DataFrame(data=comp_dict)
+    if tablechoice == "valid":
+        return component_table
+    elif tablechoice == "notDF":
+        return 5
+    elif tablechoice == "noComponent":
+        component_table.drop("Component")
+    else:
+        raise Exception(f"{tablechoice} is an invalid option for tablechoice")
+
+    return component_table
 
 
 # ----------------------------------------------------------------------
@@ -182,7 +223,7 @@ def test_validate_tree_warnings():
     """
 
     # A tree that raises all possible warnings in the validator should still be valid
-    assert ComponentSelector.validate_tree(dicts_to_test("valid"))
+    assert ComponentSelector.validate_tree(dicts_to_test("warnings"))
 
 
 def test_validate_tree_fails():
@@ -215,3 +256,127 @@ def test_validate_tree_fails():
     # Calling a function missing a required parameter should not be valid
     with pytest.raises(ComponentSelector.TreeError):
         ComponentSelector.validate_tree(dicts_to_test("missing_req_param"))
+
+
+# validate_component_table
+# -------------
+
+
+def test_validate_component_table_succeeds():
+    """
+    Tests if validate component table succeeds
+    """
+
+    assert ComponentSelector.validate_component_table(component_table_to_test("valid"))
+
+
+def test_validate_component_table_fails():
+    """
+    Tests if validate component table fails
+    """
+    with pytest.raises(TypeError):
+        ComponentSelector.validate_component_table(component_table_to_test("notDF"))
+
+    with pytest.raises(KeyError):
+        ComponentSelector.validate_component_table(
+            component_table_to_test("noComponent")
+        )
+
+
+# ComponenentSelector __init__
+# ----------------------------
+
+
+def test_Selector_init_succeeds():
+    """
+    Tests if Selector class initialization succeeds
+
+    TODO: Right now there is no failure checks within initialization
+    so there is no reason to make a failure test
+    The tree is validated in a sub-fuction and there is another
+    function that can be used to validate the component table.
+    Should anything else be validated directly within this
+    initialization?
+    """
+
+    assert ComponentSelector.ComponentSelector(
+        "minimal",
+        component_table_to_test("valid"),
+        n_echos=3,
+        n_vols=200,
+        irrelivant="arbitrary inputs are allowed",
+    )
+
+
+# ComponenentSelector select
+# ----------------------------
+
+
+def test_Selector_select_succeeds():
+    """
+    Tests if ComponentSelector.select succeeds
+
+    TODO: Right now failure checks are in subfunctions, not
+    this function, so there is no reason to make a failure test
+    Should anything else be validated directly within this
+    function?
+    """
+
+    selector = ComponentSelector.ComponentSelector(
+        "minimal", component_table_to_test("valid"), n_echos=3
+    )
+    selector.select()
+
+
+# TODO It's hard to test check_null when it's not actually being used in the minimal tree
+#   Testing for this function should be added when the kundu tree is revived.
+# def test_check_null():
+#    params = self.check_null(params, node["functionname"])
+#             kwargs = self.check_null(kwargs, node["functionname"])
+
+
+def test_are_only_necessary_metrics_used_succeeds():
+    """
+    Test that are_only_necessary_metrics_used runs with no warnings
+    and with every condition that would trigger a warning
+    TODO: I can't used assert when a function doesn't return
+    anything so I just try to run this then?
+    """
+
+    selector = ComponentSelector.ComponentSelector(
+        "minimal", component_table_to_test("valid")
+    )
+
+    # Warning: necessary metrics aren't used
+    selector.used_metrics = set()
+    selector.are_only_necessary_metrics_used()
+
+    # No warning: necessary_metrics == used_metrics
+    selector.used_metrics = selector.necessary_metrics
+    selector.are_only_necessary_metrics_used()
+
+    # Warning: used_metrics includes a metric not listed as necessary
+    selector.used_metrics.add("undeclared")
+    selector.are_only_necessary_metrics_used()
+
+
+def test_are_all_components_accepted_or_rejected_succeeds():
+    """
+    tests are_all_components_accepted_or_rejected runs with
+    and without triggering warnings
+    """
+
+    selector = ComponentSelector.ComponentSelector(
+        "minimal", component_table_to_test("valid")
+    )
+
+    selector.component_table["classification"] = "accepted"
+
+    # Runs without warnings
+    selector.are_all_components_accepted_or_rejected()
+
+    # Runs with a warning that non-final classificaitons remsin
+    selector.component_table["classification"][0] = "Intermediate1"
+    selector.component_table["classification"][1] = "Intermediate2"
+    selector.component_table["classification"][2] = "Intermediate2"
+    selector.are_all_components_accepted_or_rejected()

--- a/tedana/tests/test_ComponentSelector.py
+++ b/tedana/tests/test_ComponentSelector.py
@@ -1,4 +1,5 @@
 """Tests for the decision tree modularization"""
+from queue import Empty
 import pytest
 import pandas as pd
 import json, os, glob
@@ -329,6 +330,14 @@ def test_Selector_select_succeeds():
         "minimal", component_table_to_test("valid"), n_echos=3
     )
     selector.select()
+    assert bool(selector.used_metrics)  # Will be false of the set is empty
+    # is component_status_table created
+    assert isinstance(selector.component_status_table, pd.DataFrame)
+    # This is currently the correct number of columns for the minimal decision tree
+    assert len(selector.component_status_table.columns) == 13
+    # Every node should have an output dictionary with at least 5 elements
+    for nodeidx in range(len(selector.nodes)):
+        assert len(selector.nodes[nodeidx]["outputs"]) >= 5
 
 
 # TODO It's hard to test check_null when it's not actually being used in the minimal tree

--- a/tedana/tests/test_ComponentSelector.py
+++ b/tedana/tests/test_ComponentSelector.py
@@ -320,6 +320,9 @@ def test_Selector_select_succeeds():
     this function, so there is no reason to make a failure test
     Should anything else be validated directly within this
     function?
+
+    TODO: n_echoes should not be a required param, but this fails
+    if it's not included, I need to figure out why
     """
 
     selector = ComponentSelector.ComponentSelector(


### PR DESCRIPTION
Don't actually merge yet.

Keeping track of things done in this PR
- All functions in ComponentSelector.py except check_null have tests
- Bunch of clarified docstrings
- Several fixes to the code in response to things noticed while testing
- created validate_component_table in ComponentSelector.py
- removed a duplicated warning in are_only_necessary_metrics_used
- renamed _utils.py selection_utils.py


Things to do or testing questions
- [ ] For functions that don't return anything, I cannot use `assert` Do I just run them and the testing function will fail if they crash? Should I edit all functions to return something? A few functions, like `ComponentSelector.__init__` have error codes that are triggered in sub functions, but no actual errors checks in the main function.
- [ ] test_Selector_select_succeeds fails if I don't include n_echos as an input parameter. That shouldn't be necessary. Figure out why it is.
- [ ] check_null was partially superseded by an improved validate_tree, but the remaining case it's good for is not in the minimal tree & might be broken. If a selection node function has a required parameter, like n_echoes that isn't assigned by the decision tree, it's supposed to check if it was assigned with the initialization of the class and, if so assign the value to the function parameter. Right now, if a parameter was listed in the tree json, then it will be "", not None. If a required parameter is not listed, it will fail at the tree validation step.
- [ ] Decide if it's worthwhile to create a more rigorous validator function for the component_table
