### PR TITLE
selection_utils tests

### DIFF
--- a/tedana/selection/ComponentSelector.py
+++ b/tedana/selection/ComponentSelector.py
@@ -4,7 +4,6 @@ TE-dependent and TE-independent components.
 """
 import os.path as op
 import inspect
-import json
 import logging
 from pkg_resources import resource_filename
 from numpy import asarray

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -18,7 +18,6 @@ from tedana.selection.selection_utils import (
     get_extend_factor,
     kappa_elbow_kundu,
     # get_new_meanmetricrank,
-    # prev_classified_comps,
 )
 
 LGR = logging.getLogger("GENERAL")

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -17,8 +17,8 @@ from tedana.selection.selection_utils import (
     getelbow,
     get_extend_factor,
     kappa_elbow_kundu,
-    get_new_meanmetricrank,
-    prev_classified_comps,
+    # get_new_meanmetricrank,
+    # prev_classified_comps,
 )
 
 LGR = logging.getLogger("GENERAL")
@@ -201,7 +201,7 @@ def manual_classify(
 
     comps2use, component_table = selectcomps2use(selector, decide_comps)
 
-    if comps2use is None:
+    if not comps2use:
         log_decision_tree_step(function_name_idx, comps2use, decide_comps=decide_comps)
         outputs["numTrue"] = 0
         outputs["numFalse"] = 0
@@ -357,7 +357,7 @@ def dec_left_op_right(
         component_table, outputs["used_metrics"], function_name=function_name_idx
     )
 
-    if comps2use is None:
+    if not comps2use:
         log_decision_tree_step(function_name_idx, comps2use, decide_comps=decide_comps)
         outputs["numTrue"] = 0
         outputs["numFalse"] = 0
@@ -475,7 +475,7 @@ def dec_variance_lessthan_thresholds(
         component_table, outputs["used_metrics"], function_name=function_name_idx
     )
 
-    if comps2use is None:
+    if not comps2use:
         log_decision_tree_step(function_name_idx, comps2use, decide_comps=decide_comps)
         outputs["numTrue"] = 0
         outputs["numFalse"] = 0
@@ -625,10 +625,10 @@ def calc_kappa_rho_elbows_kundu(
 
     unclassified_comps2use = selectcomps2use(selector, "unclassified")[0]
 
-    if (comps2use is None) or (unclassified_comps2use is None):
-        if comps2use is None:
+    if (not comps2use) or (not unclassified_comps2use):
+        if not comps2use:
             log_decision_tree_step(function_name_idx, comps2use, decide_comps=decide_comps)
-        if unclassified_comps2use is None:
+        if not unclassified_comps2use:
             log_decision_tree_step(function_name_idx, comps2use, decide_comps="unclassified")
     else:
         outputs["kappa_elbow_kundu"] = kappa_elbow_kundu(component_table, selector.n_echos)
@@ -746,7 +746,7 @@ EVERTYHING BELOW HERE IS FOR THE KUNDU DECISION TREE AND IS NOT YET UPDATED
 #     comps2use = selectcomps2use(comptable, decide_comps)
 #     do_comps_exist = selectcomps2use(comptable, class_comp_exists)
 
-#     if comps2use is None:
+#     if not comps2use:
 #         log_decision_tree_step(function_name_idx, comps2use, decide_comps=decide_comps)
 #         numTrue = 0
 #         numFalse = 0
@@ -866,12 +866,12 @@ EVERTYHING BELOW HERE IS FOR THE KUNDU DECISION TREE AND IS NOT YET UPDATED
 
 #     comps2use = selectcomps2use(comptable, decide_comps)
 #     provaccept_comps2use = selectcomps2use(comptable, ["provisionalaccept"])
-#     if (comps2use is None) or (provaccept_comps2use is None):
-#         if comps2use is None:
+#     if (not comps2use) or (not provaccept_comps2use):
+#         if not comps2use:
 #             log_decision_tree_step(
 #                 function_name_idx, comps2use, decide_comps=decide_comps
 #             )
-#         if provaccept_comps2use is None:
+#         if not provaccept_comps2use:
 #             log_decision_tree_step(
 #                 function_name_idx, comps2use, decide_comps="provisionalaccept"
 #             )
@@ -994,12 +994,12 @@ EVERTYHING BELOW HERE IS FOR THE KUNDU DECISION TREE AND IS NOT YET UPDATED
 #     comps2use = selectcomps2use(comptable, decide_comps)
 #     provaccept_comps2use = selectcomps2use(comptable, ["provisionalaccept"])
 
-#     if (comps2use is None) or (provaccept_comps2use is None):
-#         if comps2use is None:
+#     if (not comps2use) or (not provaccept_comps2use):
+#         if not comps2use:
 #             log_decision_tree_step(
 #                 function_name_idx, comps2use, decide_comps=decide_comps
 #             )
-#         if provaccept_comps2use is None:
+#         if not provaccept_comps2use:
 #             log_decision_tree_step(
 #                 function_name_idx, comps2use, decide_comps="provisionalaccept"
 #             )
@@ -1144,7 +1144,7 @@ EVERTYHING BELOW HERE IS FOR THE KUNDU DECISION TREE AND IS NOT YET UPDATED
 #     )
 
 #     comps2use = selectcomps2use(comptable, decide_comps)
-#     if comps2use is None:
+#     if not comps2use:
 #         log_decision_tree_step(function_name_idx, comps2use, decide_comps=decide_comps)
 #         numTrue = 0
 #         numFalse = 0
@@ -1339,7 +1339,7 @@ EVERTYHING BELOW HERE IS FOR THE KUNDU DECISION TREE AND IS NOT YET UPDATED
 #     )
 
 #     comps2use = selectcomps2use(comptable, decide_comps)
-#     if comps2use is None:
+#     if not comps2use:
 #         log_decision_tree_step(function_name_idx, comps2use, decide_comps=decide_comps)
 #         numTrue = 0
 #         numFalse = 0
@@ -1504,7 +1504,7 @@ EVERTYHING BELOW HERE IS FOR THE KUNDU DECISION TREE AND IS NOT YET UPDATED
 #     )
 
 #     comps2use = selectcomps2use(comptable, decide_comps)
-#     if comps2use is None:
+#     if not comps2use:
 #         log_decision_tree_step(function_name_idx, comps2use, decide_comps=decide_comps)
 #         numTrue = 0
 #         numFalse = 0

--- a/tedana/selection/selection_utils.py
+++ b/tedana/selection/selection_utils.py
@@ -63,7 +63,7 @@ def selectcomps2use(selector, decide_comps):
                 component_table["classification"] == decide_comps[didx]
             ].tolist()
             comps2use = list(set(comps2use + newcomps2use))
-    elif (type(decide_comps) == list) and all(isinstance(elem, int) for elem in decide_comps):
+    elif (type(decide_comps) == list) and all(type(elem) == int for elem in decide_comps):
         # decide_comps is already a string of indices
         if len(component_table) <= max(decide_comps):
             raise ValueError(

--- a/tedana/selection/selection_utils.py
+++ b/tedana/selection/selection_utils.py
@@ -617,7 +617,7 @@ def get_extend_factor(n_vols=None, extend_factor=None):
         if n_vols < 90:
             extend_factor = 3.0
         elif n_vols < 110:
-            extend_factor = float(2 + (n_vols - 90) / 20)
+            extend_factor = 2.0 + (n_vols - 90) / 20.0
         else:
             extend_factor = float(2)
         LGR.info("extend_factor={}, based on number of fMRI volumes".format(extend_factor))

--- a/tedana/selection/selection_utils.py
+++ b/tedana/selection/selection_utils.py
@@ -615,7 +615,7 @@ def get_extend_factor(n_vols=None, extend_factor=None):
         LGR.info("extend_factor={}, as defined by user".format(extend_factor))
     elif n_vols:
         if n_vols < 90:
-            extend_factor = float(3)
+            extend_factor = 3.0
         elif n_vols < 110:
             extend_factor = float(2 + (n_vols - 90) / 20)
         else:

--- a/tedana/selection/selection_utils.py
+++ b/tedana/selection/selection_utils.py
@@ -619,7 +619,7 @@ def get_extend_factor(n_vols=None, extend_factor=None):
         elif n_vols < 110:
             extend_factor = 2.0 + (n_vols - 90) / 20.0
         else:
-            extend_factor = float(2)
+            extend_factor = 2.0
         LGR.info("extend_factor={}, based on number of fMRI volumes".format(extend_factor))
     else:
         error_msg = "get_extend_factor need n_vols or extend_factor as an input"

--- a/tedana/tests/test_selection_utils.py
+++ b/tedana/tests/test_selection_utils.py
@@ -1,8 +1,84 @@
 """Tests for the tedana.selection.selection_utils module."""
 import numpy as np
 import pytest
+import os
+import pandas as pd
 
+from tedana.selection.ComponentSelector import ComponentSelector
 from tedana.selection import selection_utils
+
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def sample_selector():
+    """
+    Retrieves a sample component table and initializes
+    a selector using that component table and the minimal tree
+    """
+
+    tree = "minimal"
+
+    sample_fname = os.path.join(THIS_DIR, "data", "sample_comptable.tsv")
+    component_table = pd.read_csv(sample_fname, delimiter="\t")
+    component_table["classification_tags"] = ""
+
+    xcomp = {
+        "n_echos": 3,
+        "n_vols": 201,
+    }
+
+    return ComponentSelector(tree, component_table, cross_component_metrics=xcomp)
+
+
+def test_selectcomps2use_succeeds():
+    """
+    Tests to make sure selectcomps2use runs with full range of inputs.
+    Include tests to make sure the correct number of components are selected
+    from the pre-defined sample_comptable.tsv component table
+    """
+    selector = sample_selector()
+
+    decide_comps_options = [
+        "rejected",
+        ["accepted"],
+        "all",
+        ["accepted", "rejected"],
+        4,
+        [2, 6, 4],
+        "NotALabel",
+    ]
+    decide_comps_lengths = [4, 17, 21, 21, 1, 3, None]
+    for idx, decide_comps in enumerate(decide_comps_options):
+        assert selection_utils.selectcomps2use(
+            selector, decide_comps
+        ), f"selectcomps2use crashed with decide_comps={decide_comps}"
+        comps2use, component_table = selection_utils.selectcomps2use(selector, decide_comps)
+        if decide_comps_lengths[idx]:
+            assert (
+                len(comps2use) > 0
+            ), f"selectcomps2use test should select {decide_comps_lengths[idx]} with decide_comps={decide_comps}, but it selected {len(comps2use)}"
+        else:
+            assert (
+                comps2use == None
+            ), f"selectcomps2use test should output None with decide_comps={decide_comps}, but it selected {len(comps2use)}"
+
+
+def test_selectcomps2use_fails():
+    """Tests for selectcomps2use failure modes"""
+    selector = sample_selector()
+
+    decide_comps_options = [
+        18.2,  # no floats
+        [11.2, 13.1],  # no list of floats
+        ["accepted", 4],  # needs to be either int or string, not both
+        [4, 3, -1, 9],  # no index should be < 0
+        [2, 4, 6, 21],  # no index should be > number of 0 indexed components
+        22,  ## no index should be > number of 0 indexed components
+    ]
+    for decide_comps in decide_comps_options:
+        with pytest.raises(ValueError):
+            selection_utils.selectcomps2use(selector, decide_comps)
 
 
 def test_getelbow_smoke():


### PR DESCRIPTION
I think this should be full testing coverage for selection_utils.py and ComponentSelector.py

I cheated slightly by commenting out two functions in selection_utils.py. Both are just used for the kundu decision tree. `get_new_meanmetricrank` will get slightly simplified when I adapt it to the new structure, so I figured I'd hold off testing until then. `prev_classified_comps` is an unholy hack and the changes we made to the structure should make it possible to eventually fully delete. I'll keep the code commented out until the kundu decision tree is refactored and functional without it.