### PR TITLE
Fixed rho threshold error and added elbows to reports

### DIFF
--- a/tedana/reporting/dynamic_figures.py
+++ b/tedana/reporting/dynamic_figures.py
@@ -124,6 +124,7 @@ def _create_data_struct(comptable_path, color_mapping=color_mapping):
             color=df["color"],
             size=df["var_exp_size"],
             classif=df["classification"],
+            classtag=df["classification_tags"],
             angle=df["angle"],
         )
     )
@@ -131,7 +132,7 @@ def _create_data_struct(comptable_path, color_mapping=color_mapping):
     return cds
 
 
-def _create_kr_plt(comptable_cds):
+def _create_kr_plt(comptable_cds, kappa_elbow=None, rho_elbow=None):
     """
     Create Dymamic Kappa/Rho Scatter Plot
 
@@ -139,6 +140,10 @@ def _create_kr_plt(comptable_cds):
     ----------
     comptable_cds: bokeh.models.ColumnDataSource
         Data structure containing a limited set of columns from the comp_table
+
+    kappa_elbow, rho_elbow: :obj:`float` :obj:`int`
+        The elbow thresholds for kappa and rho to display on the plots
+        Defaults=None
 
     Returns
     -------
@@ -152,6 +157,7 @@ def _create_kr_plt(comptable_cds):
             ("Kappa", "@kappa{0.00}"),
             ("Rho", "@rho{0.00}"),
             ("Var. Expl.", "@varexp{0.00}%"),
+            ("Tags", "@classtag"),
         ]
     )
     fig = plotting.figure(
@@ -171,6 +177,50 @@ def _create_kr_plt(comptable_cds):
         source=comptable_cds,
         legend_group="classif",
     )
+
+    if rho_elbow:
+        rho_elbow_line = models.Span(
+            location=rho_elbow,
+            dimension="width",
+            line_color="#000033",
+            line_width=1,
+            line_alpha=0.75,
+            line_dash="dashed",
+            name="rho elbow",
+        )
+        rho_elbow_label = models.Label(
+            x=300,
+            y=rho_elbow * 1.02,
+            x_units="screen",
+            text="rho elbow",
+            text_color="#000033",
+            text_alpha=0.75,
+            text_font_size="10px",
+        )
+        fig.add_layout(rho_elbow_line)
+        fig.add_layout(rho_elbow_label)
+    if kappa_elbow:
+        kappa_elbow_line = models.Span(
+            location=kappa_elbow,
+            dimension="height",
+            line_color="#000033",
+            line_width=1,
+            line_alpha=0.75,
+            line_dash="dashed",
+            name="kappa elbow",
+        )
+        kappa_elbow_label = models.Label(
+            x=kappa_elbow * 1.02,
+            y=300,
+            y_units="screen",
+            text="kappa elbow",
+            text_color="#000033",
+            text_alpha=0.75,
+            text_font_size="10px",
+        )
+        fig.add_layout(kappa_elbow_line)
+        fig.add_layout(kappa_elbow_label)
+
     fig.xaxis.axis_label = "Kappa"
     fig.yaxis.axis_label = "Rho"
     fig.toolbar.logo = None
@@ -181,7 +231,7 @@ def _create_kr_plt(comptable_cds):
 
 
 def _create_sorted_plt(
-    comptable_cds, n_comps, x_var, y_var, title=None, x_label=None, y_label=None
+    comptable_cds, n_comps, x_var, y_var, title=None, x_label=None, y_label=None, elbow=None
 ):
     """
     Create dynamic sorted plots
@@ -206,6 +256,10 @@ def _create_sorted_plt(
     y_label: str
         Y-axis label
 
+    elbow: :obj:`float` :obj:`int`
+        The elbow threshold for kappa or rho to display on the plot
+        Default=None
+
     Returns
     -------
     fig: bokeh.plotting.figure.Figure
@@ -217,6 +271,7 @@ def _create_sorted_plt(
             ("Kappa", "@kappa{0.00}"),
             ("Rho", "@rho{0.00}"),
             ("Var. Expl.", "@varexp{0.00}%"),
+            ("Tags", "@classtag"),
         ]
     )
     fig = plotting.figure(
@@ -236,6 +291,28 @@ def _create_sorted_plt(
     fig.x_range = models.Range1d(-1, n_comps + 1)
     fig.toolbar.logo = None
 
+    if elbow:
+        elbow_line = models.Span(
+            location=elbow,
+            dimension="width",
+            line_color="#000033",
+            line_width=1,
+            line_alpha=0.75,
+            line_dash="dashed",
+            name="elbow",
+        )
+        elbow_label = models.Label(
+            x=20,
+            y=elbow * 1.02,
+            x_units="screen",
+            text="elbow",
+            text_color="#000033",
+            text_alpha=0.75,
+            text_font_size="10px",
+        )
+        fig.add_layout(elbow_line)
+        fig.add_layout(elbow_label)
+
     return fig
 
 
@@ -250,6 +327,7 @@ def _create_varexp_pie_plt(comptable_cds, n_comps):
             ("Kappa", "@kappa{0.00}"),
             ("Rho", "@rho{0.00}"),
             ("Var. Exp.", "@varexp{0.00}%"),
+            ("Tags", "@classtag"),
         ],
     )
     fig.wedge(

--- a/tedana/resources/decision_trees/kundu.json
+++ b/tedana/resources/decision_trees/kundu.json
@@ -132,8 +132,8 @@
         {
             "functionname": "dec_left_op_right",
             "parameters": {
-                "ifTrue": "nochange",
-                "ifFalse": "provisionalreject",
+                "ifTrue": "provisionalreject",
+                "ifFalse": "nochange",
                 "decide_comps": [
                     "provisionalreject",
                     "provisionalaccept"

--- a/tedana/resources/decision_trees/minimal.json
+++ b/tedana/resources/decision_trees/minimal.json
@@ -114,7 +114,7 @@
             "functionname": "dec_left_op_right",
             "parameters": {
                 "ifTrue": "provisionalaccept",
-                "ifFalse": "nochange",
+                "ifFalse": "provisionalreject",
                 "decide_comps": "unclassified",
                 "op": ">",
                 "left": "kappa",
@@ -145,10 +145,10 @@
         {
             "functionname": "dec_left_op_right",
             "parameters": {
-                "ifTrue": "nochange",
-                "ifFalse": "provisionalreject",
+                "ifTrue": "provisionalreject",
+                "ifFalse": "nochange",
                 "decide_comps": [
-                    "unclassified",
+                    "provisionalreject",
                     "provisionalaccept"
                 ],
                 "op": ">",
@@ -165,10 +165,7 @@
             "parameters": {
                 "ifTrue": "accepted",
                 "ifFalse": "nochange",
-                "decide_comps": [
-                    "provisionalreject",
-                    "unclassified"
-                ]
+                "decide_comps": "provisionalreject"
             },
             "kwargs": {
                 "var_metric": "variance explained",


### PR DESCRIPTION
Changes proposed in this pull request:

- Dashed lines for kappa and rho elbows are now in the dynamic reports
- The hover text now includes classification tags
- In doing the above, I noticed I was rejecting for rho<rho_elbow instead of rho>rho_elbow in both the kundu & minimal trees. That is now corrected. The Rho elbow threshold still seems to harsh on my test data sets.
- For the sorted rank plots, I decided to label the y axes kappa or rho and give a more descriptive label to the x axes. Previously the x axes were labeled kappa or rho and there was no y_label. I realized that could be confusing.

I was going to be a good contributor and update tests in response to my additions, but updating
 https://github.com/ME-ICA/tedana/blob/a008689e7b7c3920be32d78e8c77257c5ff7dfc9/tedana/tests/test_reporting.py#L17 is beyond the scope of this PR
