### PR TITLE
Harmonizing kundu dtm with main

### DIFF
--- a/tedana/reporting/html_report.py
+++ b/tedana/reporting/html_report.py
@@ -144,7 +144,8 @@ def generate_report(io_generator, tr):
             return None
         elif len(elbow_val) > 1:
             LGR.warning(
-                f"More than one key saved in cross_component_metrics begins with {elbow_prefix}. Displaying the alphabetially first one in report"
+                "More than one key saved in cross_component_metrics begins with "
+                f"{elbow_prefix}. Displaying the alphabetially first one in report"
             )
             return elbow_val[0]
         else:

--- a/tedana/resources/decision_trees/kundu.json
+++ b/tedana/resources/decision_trees/kundu.json
@@ -138,7 +138,7 @@
                 "ifTrue": "provisionalaccept",
                 "ifFalse": "provisionalreject",
                 "decide_comps": "unclassified",
-                "op": ">",
+                "op": ">=",
                 "left": "kappa",
                 "right": "kappa_elbow_kundu"
             },

--- a/tedana/resources/decision_trees/kundu.json
+++ b/tedana/resources/decision_trees/kundu.json
@@ -129,7 +129,8 @@
             "kwargs": {
                 "log_extra_info": "",
                 "log_extra_report": ""
-            }
+            },
+            "_comment": "In original code, this was followed by a step that turned everything not rejected to ignored (accepted) if there are no unclassified components left. At this point, components are either rejected or unclassified so it is not clear how that could ever happen"
         },
         {
             "functionname": "dec_left_op_right",

--- a/tedana/resources/decision_trees/kundu.json
+++ b/tedana/resources/decision_trees/kundu.json
@@ -261,19 +261,19 @@
                     "provisionalaccept",
                     "provisionalreject"
                 ],
-                "op": "<",
+                "op": ">",
                 "left": "d_table_score",
                 "right": "max_good_meanmetricrank"
             },
             "kwargs": {
                 "tag_ifTrue": "Low variance",
-                "op2": "<",
+                "op2": "<=",
                 "left2": "variance explained",
                 "right2": "varex_lower_thresh",
-                "op3": ">",
+                "op3": "<=",
                 "left3": "kappa",
                 "right3": "kappa_elbow_kundu",
-                "log_extra_info": "If low variance and good kappa & d_table_scores accept even if rho or other metrics are bad"
+                "log_extra_info": "If low variance, accept even if bad kappa & d_table_scores"
             }
         },
         {
@@ -365,14 +365,14 @@
                 "percentile_thresh": 25
             },
             "kwargs": {
+                "num_lowest_var_comps": "num_acc_guess",
                 "log_extra_info": "Calculuate a low variance threshold based on the 25th percentile variance component"
-            },
-            "_comment": "In the original kundu code, this is run only on the first num_acc_guess remaining component... probably sorted for the lowest variance. Adding that functionality here would be messy and unlikely to significantly alter results"
+            }
         },
         {
             "functionname": "dec_left_op_right",
             "parameters": {
-                "ifTrue": "rejected",
+                "ifTrue": "accepted",
                 "ifFalse": "nochange",
                 "decide_comps": [
                     "provisionalaccept",
@@ -394,7 +394,7 @@
         {
             "functionname": "dec_left_op_right",
             "parameters": {
-                "ifTrue": "rejected",
+                "ifTrue": "accepted",
                 "ifFalse": "nochange",
                 "decide_comps": [
                     "provisionalaccept",
@@ -417,29 +417,16 @@
             "functionname": "manual_classify",
             "parameters": {
                 "new_classification": "accepted",
-                "decide_comps": "provisionalaccept"
-            },
-            "kwargs": {
-                "log_extra_info": "Anything that is still provisionalaccept should be accepted",
-                "log_extra_report": "",
-                "tag": "Likely BOLD"
-            }
-        },
-        {
-            "functionname": "manual_classify",
-            "parameters": {
-                "new_classification": "rejected",
                 "decide_comps": [
-                    "provisionalreject",
-                    "unclassified"
+                    "provisionalaccept",
+                    "provisionalreject"
                 ]
             },
             "kwargs": {
-                "log_extra_info": "Anything that is still provisionalreject should be rejected",
+                "log_extra_info": "Anything still provisional (accepted or rejected) should be accepted",
                 "log_extra_report": "",
-                "tag": "Unlikely BOLD"
-            },
-            "_comment": "According to a comment in the meica 2.7 code, nothing should be provisionalreject by this point."
+                "tag": "Likely BOLD"
+            }
         }
     ]
 }

--- a/tedana/resources/decision_trees/kundu.json
+++ b/tedana/resources/decision_trees/kundu.json
@@ -67,9 +67,20 @@
                 "right": "countsigFT2"
             },
             "kwargs": {
-                "log_extra_info": "Reject if countsig_in S0clusters > T2clusters",
+                "left2": "countsigFT2",
+                "op2": ">",
+                "right2": 0,
+                "log_extra_info": "Reject if countsig_in S0clusters > T2clusters & countsig_in_T2clusters>0",
                 "log_extra_report": "",
                 "tag_ifTrue": "Unlikely BOLD"
+            }
+        },
+        {
+            "functionname": "calc_median",
+            "parameters": {
+                "decide_comps": "all",
+                "metric_name": "variance explained",
+                "median_label": "varex"
             }
         },
         {
@@ -83,7 +94,10 @@
                 "right": "dice_FT2"
             },
             "kwargs": {
-                "log_extra_info": "Reject if DICE S0>T2",
+                "left2": "variance explained",
+                "op2": ">",
+                "right2": "median_varex",
+                "log_extra_info": "Reject if DICE S0>T2  & varex>median",
                 "log_extra_report": "",
                 "tag_ifTrue": "Unlikely BOLD"
             }
@@ -99,7 +113,10 @@
                 "right": "signal-noise_t"
             },
             "kwargs": {
-                "log_extra_info": "Reject if T2fitdiff_invsout_ICAmap_Tstat<0",
+                "left2": "variance explained",
+                "op2": ">",
+                "right2": "median_varex",
+                "log_extra_info": "Reject if T2fitdiff_invsout_ICAmap_Tstat<0 & varex>median",
                 "log_extra_report": "",
                 "tag_ifTrue": "Unlikely BOLD"
             }
@@ -295,7 +312,7 @@
                     "provisionalreject"
                 ],
                 "op": ">",
-                "left": "d_table_score_node17",
+                "left": "d_table_score_node18",
                 "right": "conservative_guess"
             },
             "kwargs": {
@@ -322,7 +339,7 @@
                     "provisionalreject"
                 ],
                 "op": ">",
-                "left": "d_table_score_node17",
+                "left": "d_table_score_node18",
                 "right": "num_acc_guess"
             },
             "kwargs": {
@@ -361,7 +378,7 @@
                     "provisionalreject"
                 ],
                 "op": ">",
-                "left": "d_table_score_node17",
+                "left": "d_table_score_node18",
                 "right": "num_acc_guess"
             },
             "kwargs": {

--- a/tedana/resources/decision_trees/minimal.json
+++ b/tedana/resources/decision_trees/minimal.json
@@ -63,9 +63,20 @@
                 "right": "countsigFT2"
             },
             "kwargs": {
-                "log_extra_info": "Reject if countsig_in S0clusters > T2clusters",
+                "left2": "countsigFT2",
+                "op2": ">",
+                "right2": 0,
+                "log_extra_info": "Reject if countsig_in S0clusters > T2clusters & countsig_in_T2clusters>0",
                 "log_extra_report": "",
                 "tag_ifTrue": "Unlikely BOLD"
+            }
+        },
+        {
+            "functionname": "calc_median",
+            "parameters": {
+                "decide_comps": "all",
+                "metric_name": "variance explained",
+                "median_label": "varex"
             }
         },
         {
@@ -79,7 +90,10 @@
                 "right": "dice_FT2"
             },
             "kwargs": {
-                "log_extra_info": "Reject if dice S0>T2",
+                "left2": "variance explained",
+                "op2": ">",
+                "right2": "median_varex",
+                "log_extra_info": "Reject if DICE S0>T2  & varex>median",
                 "log_extra_report": "",
                 "tag_ifTrue": "Unlikely BOLD"
             }
@@ -95,7 +109,10 @@
                 "right": "signal-noise_t"
             },
             "kwargs": {
-                "log_extra_info": "Reject if T2fitdiff_invsout_ICAmap_Tstat<0",
+                "left2": "variance explained",
+                "op2": ">",
+                "right2": "median_varex",
+                "log_extra_info": "Reject if T2fitdiff_invsout_ICAmap_Tstat<0 & varex>median",
                 "log_extra_report": "",
                 "tag_ifTrue": "Unlikely BOLD"
             }
@@ -116,7 +133,7 @@
                 "ifTrue": "provisionalaccept",
                 "ifFalse": "provisionalreject",
                 "decide_comps": "unclassified",
-                "op": ">",
+                "op": ">=",
                 "left": "kappa",
                 "right": "kappa_elbow_kundu"
             },

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -1217,11 +1217,13 @@ def calc_varex_thresh(
                 num_lowest_var_comps = selector.cross_component_metrics[num_lowest_var_comps]
             else:
                 raise ValueError(
-                    f"{function_name_idx}: num_lowest_var_comps ( {num_lowest_var_comps}) is not in selector.cross_component_metrics"
+                    f"{function_name_idx}: num_lowest_var_comps ( {num_lowest_var_comps}) "
+                    "is not in selector.cross_component_metrics"
                 )
         if not isinstance(num_lowest_var_comps, int):
             raise ValueError(
-                f"{function_name_idx}: num_lowest_var_comps ( {num_lowest_var_comps}) is used as an array index and should be an integer"
+                f"{function_name_idx}: num_lowest_var_comps ( {num_lowest_var_comps}) "
+                "is used as an array index and should be an integer"
             )
 
     if custom_node_label:
@@ -1251,7 +1253,8 @@ def calc_varex_thresh(
                 selector.component_table.loc[comps2use, "variance explained"], percentile_thresh
             )
         else:
-            # Using only the first num_lowest_var_comps components sorted to include lowest variance
+            # Using only the first num_lowest_var_comps components sorted to include
+            # lowest variance
             if num_lowest_var_comps <= len(comps2use):
                 sorted_varex = np.sort(
                     (selector.component_table.loc[comps2use, "variance explained"]).to_numpy()
@@ -1261,7 +1264,8 @@ def calc_varex_thresh(
                 )
             else:
                 raise ValueError(
-                    f"{function_name_idx}: num_lowest_var_comps ({num_lowest_var_comps}) needs to be <= len(comps2use) ({len(comps2use)})"
+                    f"{function_name_idx}: num_lowest_var_comps ({num_lowest_var_comps})"
+                    f"needs to be <= len(comps2use) ({len(comps2use)})"
                 )
         selector.cross_component_metrics[varex_name] = outputs[varex_name]
 


### PR DESCRIPTION
Changes proposed in this pull request:

- The modularized kundu decision tree perfectly matches the classification output of main on a single dataset.
- For the `ComponentSelector` class, if a node in a tree does not include `kwargs`, it can still run.
- All cross component metrics are the same up for >3 decimal places
- Fixed a bug in `dec_left_op_right` so that if statements raise error when a necessary parameter is None, but not 0.
- Changes include:
  - Several of the early rejection criteria were intersections of two conditional statements (i.e. bad d_table_score and high variance). This wasn't in the previous version
  - Need to add a new function `calc_median` to use with one of those additions
  - kappa threshold was >= not >. This was relevant because, the threshold can be the value of a specific component and that component should be above the threshold.
  - Noticed a mistake were a low variance node had a > flipped because main calculated it one way & then used setdiff to assign everything that failed the conditional
  - Added a parameter `num_lowest_var_comps` to `calc_varex_thresh` that calculates a percentile on a subset of selected components with the lowest variance, base on that parameter.
  - Realized there were two ignore nodes where I did everything right, but accidentally reclassified to `rejected` rather than `accepted`
  - In main, all components that fail the kappa & rho elbow thresholds are accepted unless they fail some other measure. Previously, anything that was provisionalreject at the end was rejected. In main, those are all accepted. Put another way, nothing is accepted OR rejected based primarily on the elbow thresholds that are the core measure in the original manuscripts. This is odd to me and is NOT being replicated in the minimal tree. 
- For the minimal.json tree, added the secondary clauses to the initial rejection measures and changed kappa>=kappa_elbow instead of kappa>kappa_elbow