### PR TITLE
Fixes error when a cross_component_metric doesn't exist

### DIFF
--- a/tedana/tests/test_selection_nodes.py
+++ b/tedana/tests/test_selection_nodes.py
@@ -812,6 +812,22 @@ def test_calc_varex_thresh_smoke():
             num_lowest_var_comps="NotACrossCompMetric",
         )
 
+    # Do not raise error if num_lowest_var_comps is a string & not in cross_component_metrics,
+    # but decide_comps doesn't select any components
+    selector = selection_nodes.calc_varex_thresh(
+        selector,
+        decide_comps="NoComponents",
+        thresh_label="new_lower",
+        percentile_thresh=25,
+        num_lowest_var_comps="NotACrossCompMetric",
+    )
+    assert (
+        selector.tree["nodes"][selector.current_node_idx]["outputs"]["varex_new_lower_thresh"]
+        is None
+    )
+    # percentile_thresh doesn't depend on components and is assigned
+    assert selector.tree["nodes"][selector.current_node_idx]["outputs"]["new_lower_perc"] == 25
+
     # Raise error if num_lowest_var_comps is not an integer
     with pytest.raises(ValueError):
         selector = selection_nodes.calc_varex_thresh(
@@ -833,7 +849,7 @@ def test_calc_varex_thresh_smoke():
         )
 
     # Run warning logging code to see if any of the cross_component_metrics
-    # already existed and would be over-written
+    # already exists and would be over-written
     selector = sample_selector(options="provclass")
     selector.cross_component_metrics["varex_upper_thresh"] = 1
     selector.cross_component_metrics["upper_perc"] = 1
@@ -1124,3 +1140,16 @@ def test_calc_revised_meanmetricrank_guesses_smoke():
         selector = selection_nodes.calc_revised_meanmetricrank_guesses(
             selector, ["provisional accept", "provisional reject", "unclassified"]
         )
+
+    # Do not raise error if kappa_elbow_kundu isn't in cross_component_metrics
+    # and there are no components in decide_comps
+    selector = sample_selector("provclass")
+    selector.cross_component_metrics["rho_elbow_kundu"] = 15.2
+
+    selector = selection_nodes.calc_revised_meanmetricrank_guesses(
+        selector, decide_comps="NoComponents"
+    )
+    assert selector.tree["nodes"][selector.current_node_idx]["outputs"]["num_acc_guess"] is None
+    assert (
+        selector.tree["nodes"][selector.current_node_idx]["outputs"]["conservative_guess"] is None
+    )


### PR DESCRIPTION
This should fix the bug @n-reddy reported. I can test it directly on her data because the bug didn't appear during my execution, but I created unit tests that should have replicated the underlying issue.

There were two functions in `selection_nodes.py` where there was a test to see if a cross_component_metric existed and it would raise an error if it didn't exist. If the function wouldn't actually do anything because no components were selected (i.e. if it only ran on `unclassified` components and all were classified by that point, then there was no need for an error. Now, it logs this in `LGR.info` and the code keeps running.

There is an edge case that might still cause issues. That is if a cross component metric is not calculated because no component classifications remained for that function while a later function uses that cross component metric, but is running on different component classifications that still remain. I don't think this is possible anywhere in the kundu decision tree or the minimal tree. This would be messy scenario to account for in the code and it's unlikely to happen. I placed a comment in the code in case this does arise later on.