### PR TITLE
Fixing mid kappa A  inconsistency

### DIFF
--- a/tedana/resources/decision_trees/kundu.json
+++ b/tedana/resources/decision_trees/kundu.json
@@ -53,7 +53,8 @@
                 "log_extra_info": "Reject if Kappa>Rho",
                 "log_extra_report": "",
                 "tag_ifTrue": "Unlikely BOLD"
-            }
+            },
+            "_comment": "Code I002 in premodularized tedana"
         },
         {
             "functionname": "dec_left_op_right",
@@ -72,7 +73,8 @@
                 "log_extra_info": "Reject if countsig_in S0clusters > T2clusters & countsig_in_T2clusters>0",
                 "log_extra_report": "",
                 "tag_ifTrue": "Unlikely BOLD"
-            }
+            },
+            "_comment": "Code I003 in premodularized tedana"
         },
         {
             "functionname": "calc_median",
@@ -99,7 +101,8 @@
                 "log_extra_info": "Reject if DICE S0>T2  & varex>median",
                 "log_extra_report": "",
                 "tag_ifTrue": "Unlikely BOLD"
-            }
+            },
+            "_comment": "Code I004 in premodularized tedana"
         },
         {
             "functionname": "dec_left_op_right",
@@ -118,7 +121,8 @@
                 "log_extra_info": "Reject if T2fitdiff_invsout_ICAmap_Tstat<0 & varex>median",
                 "log_extra_report": "",
                 "tag_ifTrue": "Unlikely BOLD"
-            }
+            },
+            "_comment": "Code I005 in premodularized tedana"
         },
         {
             "functionname": "calc_kappa_elbow",
@@ -190,7 +194,8 @@
                 "tag_ifTrue": "No provisional accept",
                 "log_extra_info": "If nothing is provisionally accepted by this point, be conservative and accept everything",
                 "log_extra_report": ""
-            }
+            },
+            "_comment": "Code I006 in premodularized tedana"
         },
         {
             "functionname": "calc_varex_thresh",
@@ -260,7 +265,7 @@
                 "right2": "varex_upper_thresh",
                 "log_extra_info": "If variance and d_table_scores are high, then reject"
             },
-            "_comment": "One of several steps that makes it more likely to reject high variance components"
+            "_comment": "Code I007 in premodularized tedana. One of several steps that makes it more likely to reject high variance components"
         },
         {
             "functionname": "dec_left_op_right",
@@ -284,7 +289,8 @@
                 "left3": "kappa",
                 "right3": "kappa_elbow_kundu",
                 "log_extra_info": "If low variance, accept even if bad kappa & d_table_scores"
-            }
+            },
+            "_comment": "Code I008 in premodularized tedana"
         },
         {
             "functionname": "dec_classification_doesnt_exist",
@@ -300,7 +306,8 @@
                 "tag_ifTrue": "Likely BOLD",
                 "log_extra_info": "If nothing left is unclassified, then accept all",
                 "log_extra_report": ""
-            }
+            },
+            "_comment": "No code in premodularized tedana"
         },
         {
             "functionname": "calc_revised_meanmetricrank_guesses",
@@ -338,7 +345,7 @@
                 "right3_scale": "extend_factor",
                 "log_extra_info": "Reject if a combination of kappa, variance, and other factors are ranked worse than others"
             },
-            "_comment": "Quirky combination 1 of a bunch of metrics that deal with rejecting some edge cases"
+            "_comment": "Code I009 in premodularized tedana. Quirky combination 1 of a bunch of metrics that deal with rejecting some edge cases"
         },
         {
             "functionname": "dec_left_op_right",
@@ -362,7 +369,7 @@
                 "right2_scale": "extend_factor",
                 "log_extra_info": "Reject if a combination of variance and ranks of other metrics are worse than others"
             },
-            "_comment": "Quirky combination 2 of a bunch of metrics that deal with rejecting some edge cases"
+            "_comment": "Code I010 in premodularized tedana. Quirky combination 2 of a bunch of metrics that deal with rejecting some edge cases"
         },
         {
             "functionname": "calc_varex_thresh",
@@ -399,7 +406,7 @@
                 "right2": "varex_new_lower_thresh",
                 "log_extra_info": "Accept components with a bad d_table_score, but are at the higher end of the remaining variance so more cautious to not remove"
             },
-            "_comment": "Yet another quirky criterion, but this one to keep components. In the original tree, varex_new_lower_thresh would be lower than it is here. If there are differences in results, might be worth adding a scaling factor"
+            "_comment": "Code I011 in premodularized tedana. Yet another quirky criterion, but this one to keep components. In the original tree, varex_new_lower_thresh would be lower than it is here. If there are differences in results, might be worth adding a scaling factor"
         },
         {
             "functionname": "dec_left_op_right",
@@ -421,7 +428,7 @@
                 "right2": "varex_new_lower_thresh",
                 "log_extra_info": "Accept components above the kappa elbow, but are at the higher end of the remaining variance so more cautious to not remove"
             },
-            "_comment": "Yet another quirky criterion, but this one to keep components. In the original tree, varex_new_lower_thresh would be lower than it is here. If there are differences in results, might be worth adding a scaling factor"
+            "_comment": "Code I012 in premodularized tedana. Yet another quirky criterion, but this one to keep components. In the original tree, varex_new_lower_thresh would be lower than it is here. If there are differences in results, might be worth adding a scaling factor"
         },
         {
             "functionname": "manual_classify",
@@ -436,7 +443,8 @@
                 "log_extra_info": "Anything still provisional (accepted or rejected) should be accepted",
                 "log_extra_report": "",
                 "tag": "Likely BOLD"
-            }
+            },
+            "_comment": "No code in the premodularized tedana"
         }
     ]
 }

--- a/tedana/resources/decision_trees/minimal.json
+++ b/tedana/resources/decision_trees/minimal.json
@@ -167,9 +167,9 @@
                 "right": "rho"
             },
             "kwargs": {
-                "log_extra_info": "If kappa>elbow and kappa>3*rho accept even if rho>elbow",
+                "log_extra_info": "If kappa>elbow and kappa>2*rho accept even if rho>elbow",
                 "log_extra_report": "",
-                "right_scale": 3,
+                "right_scale": 2,
                 "tag_ifTrue": "Likely BOLD"
             }
         },

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -1512,7 +1512,7 @@ def calc_varex_kappa_ratio(
     only_used_metrics=False,
 ):
     """
-    Calculates the cross_component_metric, kappa_rate, for the components in decide_comps
+    Calculates the cross_component_metric ``kappa_rate`` for the components in decide_comps
     and then calculate the variance explained / kappa ratio for ALL components
     and adds those values to a new column in the component_table titled "varex kappa ratio".
 

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -1512,9 +1512,9 @@ def calc_varex_kappa_ratio(
     only_used_metrics=False,
 ):
     """
-    Calculates the variance explained / kappa ratio for the componentse in decide_comps
-    and add those values to a new column in the component_table titled "varex kappa ratio".
-    Also calculated kappa_rate which is a cross_component_metric
+    Calculates the cross_component_metric, kappa_rate, for the components in decide_comps
+    and then calculate the variance explained / kappa ratio for ALL components
+    and adds those values to a new column in the component_table titled "varex kappa ratio".
 
     Parameters
     ----------
@@ -1596,10 +1596,12 @@ def calc_varex_kappa_ratio(
         )
         outputs["kappa_rate"] = kappa_rate
         LGR.info(f"Kappa rate found to be {kappa_rate} from components " f"{comps2use}")
+        # NOTE: kappa_rate is calculated on a subset of components while
+        #     "varex kappa ratio" is calculated for all compnents
         selector.component_table["varex kappa ratio"] = (
             kappa_rate
-            * selector.component_table.loc[comps2use, "variance explained"]
-            / selector.component_table.loc[comps2use, "kappa"]
+            * selector.component_table["variance explained"]
+            / selector.component_table["kappa"]
         )
         # Unclear if necessary, but this may clean up a weird issue on passing
         # references in a data frame.


### PR DESCRIPTION
I think I figured out where the kundu decision tree in Main differs from the results we were getting in the modularized decision tree. I'm now getting the same results for both on the data @n-reddy shared with me. She can check if the results now much across other runs of her data

Changes proposed in this pull request:

- `calc_varex_kappa_ratio` appropriately calculated the constant `kappa_rate` on just `provisionalaccept` components. In the original code, this constant was used to calculate a `kappa_ratio` (now `varex kappa ratio`) for all components, but we were only calculating it on `provisionalaccept` components. When this threshold was then applied to `unclassified` components, the value was `n/a` and it was always returning False
- Added the `I0??` codes to the `_comment` fields in `kundu.json` That field won't be output anywhere, but i decided it would be a useful addition for the sake of helping me & others understand the code.
- A change unrelated to the mid kappa A inconsistency: The minimal tree used to accept components with kappa>elbow and kappa>3rho. This changes that to kappa>2rho.
