### PR TITLE
Fixed NoLikelyBOLDBug

### DIFF
--- a/docs/building decision trees.rst
+++ b/docs/building decision trees.rst
@@ -221,7 +221,9 @@ that Are used to checks whether results are plausible & can help avoid mistakes
       A list of acceptable classification tags (i.e. "Likely BOLD", "Unlikely BOLD",
       "Low variance"). This will both be used to make sure only these tags are used in
       the tree and allow programs that interact with the results to see all potential
-      tags in one place.
+      tags in one place. Note: "Likely BOLD" is a required tag. If tedana is run and
+      none of the components include the "Likely BOLD" tag, then ICA will be repeated
+      with a different seed and then the selection process will repeat.
 
 **Nodes in the decision tree**
 

--- a/tedana/selection/component_selector.py
+++ b/tedana/selection/component_selector.py
@@ -510,8 +510,26 @@ class ComponentSelector:
         return len(self.component_table)
 
     @property
+    def LikelyBOLD_comps(self):
+        """A boolean pd.DataSeries of components that are tagged "Likely BOLD"."""
+        LikelyBOLD_comps = self.component_table["classification_tags"].copy()
+        print(LikelyBOLD_comps)
+        for idx in range(len(LikelyBOLD_comps)):
+            if "Likely BOLD" in LikelyBOLD_comps.loc[idx]:
+                LikelyBOLD_comps.loc[idx] = True
+            else:
+                LikelyBOLD_comps.loc[idx] = False
+        print(LikelyBOLD_comps)
+        return LikelyBOLD_comps
+
+    @property
+    def n_LikelyBOLD_comps(self):
+        """The number of components that are tagged "Likely BOLD"."""
+        return self.LikelyBOLD_comps.sum()
+
+    @property
     def accepted_comps(self):
-        """The indices of components that are accepted."""
+        """A boolean pd.DataSeries of components that are accepted."""
         return self.component_table["classification"] == "accepted"
 
     @property
@@ -521,7 +539,7 @@ class ComponentSelector:
 
     @property
     def rejected_comps(self):
-        """The indices of components that are rejected."""
+        """A boolean pd.DataSeries of components that are rejected."""
         return self.component_table["classification"] == "rejected"
 
     def to_files(self, io_generator):

--- a/tedana/tests/test_component_selector.py
+++ b/tedana/tests/test_component_selector.py
@@ -312,3 +312,18 @@ def test_are_all_components_accepted_or_rejected():
     selector.component_table.loc[7, "classification"] = "intermediate1"
     selector.component_table.loc[[1, 3, 5], "classification"] = "intermediate2"
     selector.are_all_components_accepted_or_rejected()
+
+
+def test_selector_properties_smoke():
+    """Tests to confirm properties match expected results"""
+
+    selector = component_selector.ComponentSelector("minimal", sample_comptable())
+
+    assert selector.n_comps == 21
+
+    # Also runs selector.LikelyBOLD_comps and should need to deal with sets in each field
+    assert selector.n_LikelyBOLD_comps == 17
+
+    assert selector.n_accepted_comps == 17
+
+    assert selector.rejected_comps.sum() == 4

--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -399,7 +399,7 @@ def test_integration_reclassify_no_bold(skip_integration, caplog):
         out_dir=out_dir,
         no_reports=True,
     )
-    assert "No BOLD components detected!" in caplog.text
+    assert "No accepted components remaining after manual classification!" in caplog.text
 
     fn = resource_filename("tedana", "tests/data/reclassify_no_bold.txt")
     check_integration_outputs(fn, out_dir)

--- a/tedana/utils.py
+++ b/tedana/utils.py
@@ -76,6 +76,12 @@ def make_adaptive_mask(data, mask=None, getsum=False, threshold=1):
 
     # get 33rd %ile of `first_echo` and find corresponding index
     # NOTE: percentile is arbitrary
+    # TODO: "interpolation" param changed to "method" in numpy 1.22.0
+    #       confirm method="higher" is the same as interpolation="higher"
+    #       Current minimum version for numpy in tedana is 1.16 where
+    #       there is no "method" parameter. Either wait until we bump
+    #       our minimum numpy version to 1.22 or add a version check
+    #       or try/catch statement.
     perc = np.percentile(first_echo, 33, interpolation="higher")
     perc_val = echo_means[:, 0] == perc
 

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -658,10 +658,10 @@ def tedana_workflow(
                 metrics=required_metrics,
             )
             ica_selection = selection.automatic_selection(comptable, n_echos, n_vols, tree=tree)
-            n_accepted_comps = ica_selection.n_accepted_comps
-            if (n_restarts < maxrestart) and (n_accepted_comps == 0):
+            n_LikelyBOLD_comps = ica_selection.n_LikelyBOLD_comps
+            if (n_restarts < maxrestart) and (n_LikelyBOLD_comps == 0):
                 LGR.warning("No BOLD components found. Re-attempting ICA.")
-            elif n_accepted_comps == 0:
+            elif n_LikelyBOLD_comps == 0:
                 LGR.warning("No BOLD components found, but maximum number of restarts reached.")
                 keep_restarting = False
             else:
@@ -732,7 +732,7 @@ def tedana_workflow(
         }
     io_generator.save_file(decomp_metadata, "ICA decomposition json")
 
-    if ica_selection.n_accepted_comps == 0:
+    if ica_selection.n_LikelyBOLD_comps == 0:
         LGR.warning("No BOLD components detected! Please check data and results!")
 
     # TODO: un-hack separate comptable

--- a/tedana/workflows/tedana_reclassify.py
+++ b/tedana/workflows/tedana_reclassify.py
@@ -316,7 +316,9 @@ def post_tedana(
     selector.to_files(io_generator)
 
     if selector.n_accepted_comps == 0:
-        LGR.warning("No BOLD components detected! Please check data and results!")
+        LGR.warning(
+            "No accepted components remaining after manual classification! Please check data and results!"
+        )
 
     mmix_orig = mmix.copy()
     # TODO: make this a function


### PR DESCRIPTION
@jbteves noticed a bug. In the current tedana, if no accepted components are identified then ICA is repeated with a different seed. In this branch, since ignored components were replaced by accepted + a descriptive classification tag, this repetition would never happen. I confirmed that everything that used to be `accepted` now contains the `Likely BOLD` classification_tag

Changes:
- New LikelyBOLD_comps and n_LikelyBOLD_comps properties added to component_selector.py
- Tests for all the properties (which verify results) were added
- tedana.py will now repeat ICA if no components contain the `Likely BOLD` classification_tag
- tedana_reclassify.py will still give a warning based on no accepted components rather than Likely BOLD tags. (The logic is, if reclassification as removed everything accepted, that's the warning. Reclassification will never add or remove a `Likely BOLD` tag so it's not a useful check there.
- Documentation updated to note that `Likely BOLD` is a required classification_tag

Notes:
- I confirmed this is doing what it's supposed to, but I can't replicate the integration test where this first occurred so @jbteves should do that & make sure the results now match. (Maybe make a more consistent integration test for this issue?)
- Take a look at the LikelyBOLD_comps property. pd Dataseries have some weird edge cases in my hands to make sure I didn't mess anything up.
- One other general thing for this PR. In every file, the `component_selector` is called `selector` except in tedana.py where it's called `ica_selection` Any reason NOT to change that to `selector` for consistency?
