### PR TITLE
Fixed i007 divergance and calc_varex_thresh

### DIFF
--- a/tedana/resources/decision_trees/kundu.json
+++ b/tedana/resources/decision_trees/kundu.json
@@ -249,6 +249,7 @@
                 "op2": ">",
                 "left2": "variance explained",
                 "right2": "varex_upper_thresh",
+                "right2_scale": "extend_factor",
                 "log_extra_info": "If variance and d_table_scores are high, then reject",
                 "tag_ifTrue": "Less likely BOLD"
             },

--- a/tedana/resources/decision_trees/kundu.json
+++ b/tedana/resources/decision_trees/kundu.json
@@ -370,7 +370,7 @@
                 "percentile_thresh": 25
             },
             "kwargs": {
-                "num_lowest_var_comps": "num_acc_guess"
+                "num_highest_var_comps": "num_acc_guess"
             }
         },
         {

--- a/tedana/selection/component_selector.py
+++ b/tedana/selection/component_selector.py
@@ -388,7 +388,8 @@ class ComponentSelector:
                 all_params = {**params}
 
             LGR.debug(
-                f"Step {self.current_node_idx}: Running function {node['functionname']} with parameters: {all_params}"
+                f"Step {self.current_node_idx}: Running function {node['functionname']} "
+                f"with parameters: {all_params}"
             )
             # run the decision node function
             if kwargs is not None:
@@ -402,7 +403,8 @@ class ComponentSelector:
             # log the current counts for all classification labels
             log_classification_counts(self.current_node_idx, self.component_table)
             LGR.debug(
-                f"Step {self.current_node_idx} Full outputs: {self.tree['nodes'][self.current_node_idx]['outputs']}"
+                f"Step {self.current_node_idx} Full outputs: "
+                f"{self.tree['nodes'][self.current_node_idx]['outputs']}"
             )
         # move decision columns to end
         self.component_table = clean_dataframe(self.component_table)

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -1074,9 +1074,10 @@ def dec_classification_doesnt_exist(
             "node_label"
         ] = f"Change {decide_comps} to {new_classification} if {class_comp_exists} doesn't exist"
     else:
-        outputs[
-            "node_label"
-        ] = f"Change {decide_comps} to {new_classification} if less than {at_least_num_exist} components with {class_comp_exists} exist"
+        outputs["node_label"] = (
+            f"Change {decide_comps} to {new_classification} if less than "
+            f"{at_least_num_exist} components with {class_comp_exists} exist"
+        )
 
     LGR.info(f"{function_name_idx}: {outputs['node_label']}")
     if log_extra_info:

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -1137,7 +1137,7 @@ def calc_varex_thresh(
     decide_comps,
     thresh_label,
     percentile_thresh,
-    num_lowest_var_comps=None,
+    num_highest_var_comps=None,
     log_extra_report="",
     log_extra_info="",
     custom_node_label="",
@@ -1159,8 +1159,8 @@ def calc_varex_thresh(
         A percentile threshold to apply to components to set the variance threshold.
         In the original kundu decision tree this was 90 for varex_upper_thresh and
         25 for varex_lower_thresh
-    num_lowest_var_comps: :obj:`str` :obj:`int`
-        percentile can be calculated on the num_lowest_var_comps components with the
+    num_highest_var_comps: :obj:`str` :obj:`int`
+        percentile can be calculated on the num_highest_var_comps components with the
         lowest variance. Either input an integer directly or input a string that is
         a parameter stored in selector.cross_component_metrics ("num_acc_guess" in
         original decision tree). Default=None
@@ -1188,7 +1188,7 @@ def calc_varex_thresh(
         "decision_node_idx": selector.current_node_idx,
         "node_label": None,
         varex_name: None,
-        "num_lowest_var_comps": num_lowest_var_comps,
+        "num_highest_var_comps": num_highest_var_comps,
         "used_metrics": set(["variance explained"]),
     }
     if (
@@ -1221,28 +1221,28 @@ def calc_varex_thresh(
         selector.component_table, outputs["used_metrics"], function_name=function_name_idx
     )
 
-    if num_lowest_var_comps is not None:
-        if isinstance(num_lowest_var_comps, str):
-            if num_lowest_var_comps in selector.cross_component_metrics:
-                num_lowest_var_comps = selector.cross_component_metrics[num_lowest_var_comps]
+    if num_highest_var_comps is not None:
+        if isinstance(num_highest_var_comps, str):
+            if num_highest_var_comps in selector.cross_component_metrics:
+                num_highest_var_comps = selector.cross_component_metrics[num_highest_var_comps]
             elif not comps2use:
                 # Note: It is possible the comps2use requested for this function
                 #  is not empty, but the comps2use requested to calculate
-                # {num_lowest_var_comps} was empty. Given the way this node is
+                # {num_highest_var_comps} was empty. Given the way this node is
                 # used, that's unlikely, but worth a comment.
                 LGR.info(
-                    f"{function_name_idx}:  num_lowest_var_comps ( {num_lowest_var_comps}) "
+                    f"{function_name_idx}:  num_highest_var_comps ( {num_highest_var_comps}) "
                     "is not in selector.cross_component_metrics, but no components with "
                     f"{decide_comps} remain by this node so nothing happens"
                 )
             else:
                 raise ValueError(
-                    f"{function_name_idx}: num_lowest_var_comps ( {num_lowest_var_comps}) "
+                    f"{function_name_idx}: num_highest_var_comps ( {num_highest_var_comps}) "
                     "is not in selector.cross_component_metrics"
                 )
-        if not isinstance(num_lowest_var_comps, int) and comps2use:
+        if not isinstance(num_highest_var_comps, int) and comps2use:
             raise ValueError(
-                f"{function_name_idx}: num_lowest_var_comps ( {num_lowest_var_comps}) "
+                f"{function_name_idx}: num_highest_var_comps ( {num_highest_var_comps}) "
                 "is used as an array index and should be an integer"
             )
 
@@ -1264,23 +1264,25 @@ def calc_varex_thresh(
             decide_comps=decide_comps,
         )
     else:
-        if num_lowest_var_comps is None:
+        if num_highest_var_comps is None:
             outputs[varex_name] = scoreatpercentile(
                 selector.component_table.loc[comps2use, "variance explained"], percentile_thresh
             )
         else:
-            # Using only the first num_lowest_var_comps components sorted to include
+            # Using only the first num_highest_var_comps components sorted to include
             # lowest variance
-            if num_lowest_var_comps <= len(comps2use):
-                sorted_varex = np.sort(
-                    (selector.component_table.loc[comps2use, "variance explained"]).to_numpy()
+            if num_highest_var_comps <= len(comps2use):
+                sorted_varex = np.flip(
+                    np.sort(
+                        (selector.component_table.loc[comps2use, "variance explained"]).to_numpy()
+                    )
                 )
                 outputs[varex_name] = scoreatpercentile(
-                    sorted_varex[:num_lowest_var_comps], percentile_thresh
+                    sorted_varex[:num_highest_var_comps], percentile_thresh
                 )
             else:
                 raise ValueError(
-                    f"{function_name_idx}: num_lowest_var_comps ({num_lowest_var_comps})"
+                    f"{function_name_idx}: num_highest_var_comps ({num_highest_var_comps})"
                     f"needs to be <= len(comps2use) ({len(comps2use)})"
                 )
         selector.cross_component_metrics[varex_name] = outputs[varex_name]

--- a/tedana/tests/test_selection_nodes.py
+++ b/tedana/tests/test_selection_nodes.py
@@ -817,13 +817,13 @@ def test_calc_varex_thresh_smoke():
     assert selector.tree["nodes"][selector.current_node_idx]["outputs"]["varex_thresh"] > 0
     assert selector.tree["nodes"][selector.current_node_idx]["outputs"]["perc"] == 90
 
-    # Standard call using num_lowest_var_comps as an integer
+    # Standard call using num_highest_var_comps as an integer
     selector = selection_nodes.calc_varex_thresh(
         selector,
         decide_comps,
         thresh_label="new_lower",
         percentile_thresh=25,
-        num_lowest_var_comps=8,
+        num_highest_var_comps=8,
     )
     calc_cross_comp_metrics = {"varex_new_lower_thresh", "new_lower_perc"}
     output_calc_cross_comp_metrics = set(
@@ -836,14 +836,14 @@ def test_calc_varex_thresh_smoke():
     )
     assert selector.tree["nodes"][selector.current_node_idx]["outputs"]["new_lower_perc"] == 25
 
-    # Standard call using num_lowest_var_comps as a value in cross_component_metrics
+    # Standard call using num_highest_var_comps as a value in cross_component_metrics
     selector.cross_component_metrics["num_acc_guess"] = 10
     selector = selection_nodes.calc_varex_thresh(
         selector,
         decide_comps,
         thresh_label="new_lower",
         percentile_thresh=25,
-        num_lowest_var_comps="num_acc_guess",
+        num_highest_var_comps="num_acc_guess",
     )
     calc_cross_comp_metrics = {"varex_new_lower_thresh", "new_lower_perc"}
     output_calc_cross_comp_metrics = set(
@@ -856,24 +856,24 @@ def test_calc_varex_thresh_smoke():
     )
     assert selector.tree["nodes"][selector.current_node_idx]["outputs"]["new_lower_perc"] == 25
 
-    # Raise error if num_lowest_var_comps is a string, but not in cross_component_metrics
+    # Raise error if num_highest_var_comps is a string, but not in cross_component_metrics
     with pytest.raises(ValueError):
         selector = selection_nodes.calc_varex_thresh(
             selector,
             decide_comps,
             thresh_label="new_lower",
             percentile_thresh=25,
-            num_lowest_var_comps="NotACrossCompMetric",
+            num_highest_var_comps="NotACrossCompMetric",
         )
 
-    # Do not raise error if num_lowest_var_comps is a string & not in cross_component_metrics,
+    # Do not raise error if num_highest_var_comps is a string & not in cross_component_metrics,
     # but decide_comps doesn't select any components
     selector = selection_nodes.calc_varex_thresh(
         selector,
         decide_comps="NoComponents",
         thresh_label="new_lower",
         percentile_thresh=25,
-        num_lowest_var_comps="NotACrossCompMetric",
+        num_highest_var_comps="NotACrossCompMetric",
     )
     assert (
         selector.tree["nodes"][selector.current_node_idx]["outputs"]["varex_new_lower_thresh"]
@@ -882,24 +882,24 @@ def test_calc_varex_thresh_smoke():
     # percentile_thresh doesn't depend on components and is assigned
     assert selector.tree["nodes"][selector.current_node_idx]["outputs"]["new_lower_perc"] == 25
 
-    # Raise error if num_lowest_var_comps is not an integer
+    # Raise error if num_highest_var_comps is not an integer
     with pytest.raises(ValueError):
         selector = selection_nodes.calc_varex_thresh(
             selector,
             decide_comps,
             thresh_label="new_lower",
             percentile_thresh=25,
-            num_lowest_var_comps=9.5,
+            num_highest_var_comps=9.5,
         )
 
-    # Raise error if num_lowest_var_comps is larger than the number of selected components
+    # Raise error if num_highest_var_comps is larger than the number of selected components
     with pytest.raises(ValueError):
         selector = selection_nodes.calc_varex_thresh(
             selector,
             decide_comps,
             thresh_label="new_lower",
             percentile_thresh=25,
-            num_lowest_var_comps=55,
+            num_highest_var_comps=55,
         )
 
     # Run warning logging code to see if any of the cross_component_metrics

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -672,7 +672,7 @@ def tedana_workflow(
                 io_generator.force = True
             RepLGR.disabled = True  # Disable the report to avoid duplicate text
         RepLGR.disabled = False  # Re-enable the report after the while loop is escaped
-        io_generator.force = force # Re-enable original overwrite behavior
+        io_generator.force = force  # Re-enable original overwrite behavior
     else:
         LGR.info("Using supplied mixing matrix from ICA")
         mixing_file = io_generator.get_name("ICA mixing tsv")

--- a/tedana/workflows/tedana_reclassify.py
+++ b/tedana/workflows/tedana_reclassify.py
@@ -320,7 +320,8 @@ def post_tedana(
 
     if selector.n_accepted_comps == 0:
         LGR.warning(
-            "No accepted components remaining after manual classification! Please check data and results!"
+            "No accepted components remaining after manual classification! "
+            "Please check data and results!"
         )
 
     mmix_orig = mmix.copy()


### PR DESCRIPTION
Changes proposed in this pull request:

- Added extend_factor to step 16 to align with Main
- I think calc_varex_thresh should have an option to pick the highest variance vs lowest variance components so changed the options to account for that.

Several integration tests are now failing. Possibly because outputs are now changed & something isn't matching. Other possability is some test is cached & messing things up.
