### PR TITLE
Changing a few np.integer to np.int32

### DIFF
--- a/tedana/io.py
+++ b/tedana/io.py
@@ -41,7 +41,7 @@ class CustomEncoder(json.JSONEncoder):
 
     def default(self, obj):
         # int64 non-serializable but is a numpy output
-        if isinstance(obj, np.integer):
+        if isinstance(obj, np.int32):
             return int(obj)
 
         # containers that are not serializable

--- a/tedana/selection/selection_utils.py
+++ b/tedana/selection/selection_utils.py
@@ -513,7 +513,7 @@ def getelbow_cons(arr, return_val=False):
         (arr[nk - 5 - ii - 1] > arr[nk - 5 - ii : nk].mean() + 2 * arr[nk - 5 - ii : nk].std())
         for ii in range(nk - 5)
     ]
-    ds = np.array(temp1[::-1], dtype=np.integer)
+    ds = np.array(temp1[::-1], dtype=np.int32)
     dsum = []
     c_ = 0
     for d_ in ds:

--- a/tedana/tests/test_selection_utils.py
+++ b/tedana/tests/test_selection_utils.py
@@ -315,7 +315,7 @@ def test_getelbow_smoke():
     """A smoke test for the getelbow function."""
     arr = np.random.random(100)
     idx = selection_utils.getelbow(arr)
-    assert isinstance(idx, np.integer)
+    assert isinstance(idx, np.int32)
 
     val = selection_utils.getelbow(arr, return_val=True)
     assert isinstance(val, float)
@@ -335,7 +335,7 @@ def test_getelbow_cons_smoke():
     """A smoke test for the getelbow_cons function."""
     arr = np.random.random(100)
     idx = selection_utils.getelbow_cons(arr)
-    assert isinstance(idx, np.integer)
+    assert isinstance(idx, np.int32)
 
     val = selection_utils.getelbow_cons(arr, return_val=True)
     assert isinstance(val, float)


### PR DESCRIPTION
Changes proposed in this pull request:

- I think we decided to standardize on `np.int32` rather than `np.integer` so I'm just doing it
- `int()` is also used a bunch of times in the code Not sure if any of those may cause problems or if we can leave them as is.
