### PR TITLE
DTM documentation review

### DIFF
--- a/docs/building decision trees.rst
+++ b/docs/building decision trees.rst
@@ -61,9 +61,9 @@ New columns in ``selector.component_table`` and the "ICA metrics tsv" file:
         for visualizing and reviewing results
 
 ``selector.cross_component_metrics`` and "ICA cross component metrics json":
-    A dictionary of metrics that are each a single value calculated across components.
-    For example, kappa and rho elbows. User or pre-defined scaling factors are
-    also be stored here. Any constant that is used in the component classification
+    A dictionary of metrics that are each a single value calculated across components,
+    for example, kappa and rho elbows. User or pre-defined scaling factors are
+    also stored here. Any constant that is used in the component classification
     processes that isn't pre-defined in the decision tree file should be saved here.
 
 ``selector.component_status_table`` and "ICA status table tsv":
@@ -105,10 +105,10 @@ New columns in ``selector.component_table`` and the "ICA metrics tsv" file:
 for each "node" or function call. For each node, there is an "outputs" subfield with
 information from when the tree was executed. Each outputs field includes:
 
-decison_node_idx:
+decision_node_idx:
     The decision tree functions are run as part of an ordered list.
-    This is the positional index the location of the function in
-    the list, starting with index 0.
+    This is the positional index (the location of the function in
+    the list), starting with index 0.
 
 used_metrics:
     A list of the metrics used in a node of the decision tree
@@ -122,7 +122,7 @@ node_label:
 
 n_true, n_false:
     For decision tree (dec) functions, the number of components that were classified
-    as true or false respectively in this decision tree step.
+    as true or false, respectively, in this decision tree step.
 
 calc_cross_comp_metrics:
     For calculation (calc) functions, cross component metrics that were
@@ -144,10 +144,10 @@ Defining a custom decision tree
 *******************************
 
 Decision trees are stored in json files. The default trees are stored as part of
-the tedana code repository in `resources/decision_trees`_ The minimal tree,
-minimal.json is a good example highlighting the structure and steps in a tree. It
+the tedana code repository in `resources/decision_trees`_. The minimal tree,
+minimal.json, is a good example highlighting the structure and steps in a tree. It
 may be helpful to look at that tree while reading this section. kundu.json replicates
-the decision tree used in MEICA version 2.5, the predecessor to tedana. It is a more
+the decision tree used in MEICA version 2.5, the predecessor to tedana. It is more
 complex, but also highlights additional possible functionality in decision trees.
 
 A user can specify another decision tree and link to the tree location when tedana is
@@ -178,7 +178,7 @@ in `selection_nodes.py`_
 
 There are several fields with general information. Some of these store general
 information that's useful for reporting results and others store information
-that Are used to checks whether results are plausible & can help avoid mistakes
+that is used to check whether results are plausible & can help avoid mistakes.
 
   tree_id:
       A descriptive name for the tree that will be logged.
@@ -193,15 +193,15 @@ that Are used to checks whether results are plausible & can help avoid mistakes
       Publications that should be referenced when this tree is used
 
   necessary_metrics:
-      Is a list of the necessary metrics in the component table that will be used
+      A list of the necessary metrics in the component table that will be used
       by the tree. If a metric doesn't exist then this will raise an error instead
       of executing a tree. (Depending on future code development, this could
       potentially be used to run ``tedana`` by specifying a decision tree and
-      metrics are calculated base on the contents of this field.) If a necessary
+      metrics are calculated based on the contents of this field.) If a necessary
       metric isn't used, there will be a warning.
 
   generated_metrics:
-    Is an optional initial field. It lists metrics that are to be calculated as
+    An optional initial field. It lists metrics that are to be calculated as
     part of the decision tree's execution. This is used similarly to necessary_metrics
     except, since the decision tree starts before these metrics exist, it won't raise
     an error when these metrics are not found. One might want to calculate a new metric
@@ -246,15 +246,15 @@ There are several key fields for each node:
 - "parameters": Specifications of all required parameters for the function in functionname
 - "kwargs": Specifications for optional parameters for the function in functionname
 
-The only parameter that is used in all functions is "decidecomps" which is used to
+The only parameter that is used in all functions is "decidecomps", which is used to
 identify, based on their classifications, the components a function should be applied
 to. It can be a single classification, or a comma separated string of classifications.
 In addition to the intermediate and default ("accepted" "rejected" "unclassified")
 component classifications, this can be "all" for functions that should be applied to
 all components regardless of their classifications.
 
-Most decision functions also include "if_true" and "if_false" which specify how to change
-the classification of each component based on whether a the decision criterion is true
+Most decision functions also include "if_true" and "if_false", which specify how to change
+the classification of each component based on whether a decision criterion is true
 or false. In addition to the default and intermediate classification options, this can
 also be "nochange" (i.e. For components where a>b is true, "reject". For components
 where a>b is false, "nochange"). The optional parameters "tag_if_true" and "tag_if_false"
@@ -316,7 +316,7 @@ Before any data are touched in the function, there should be an
 call. This will be useful to gather all metrics a tree will use without requiring a
 specific dataset.
 
-Existing functions define ``function_name_idx = f"Step {selector.current_node_idx}: [text of function_name]``
+Existing functions define ``function_name_idx = f"Step {selector.current_node_idx}: [text of function_name]``.
 This is used in logging and is cleaner to initialize near the top of each function.
 
 
@@ -331,9 +331,9 @@ and output a warning if the function overwrites an existing value
 Code that adds the text ``log_extra_info`` and ``log_extra_report`` into the appropriate
 logs (if they are provided by the user)
 
-After the above information is included, all functions will call ``selectcomps2use``
+After the above information is included, all functions will call ``selectcomps2use``,
 which returns the components with classifications included in ``decide_comps``
-and then runs ``confirm_metrics_exist`` which is an added check to make sure the metrics
+and then runs ``confirm_metrics_exist``, which is an added check to make sure the metrics
 used by this function exist in the component table.
 
 Nearly every function has a clause like:
@@ -346,12 +346,12 @@ Nearly every function has a clause like:
       outputs["n_false"] = 0
   else:
 
-If there are no components with the classifications in ``decide_comps`` this logs that
+If there are no components with the classifications in ``decide_comps``, this logs that
 there's nothing for the function to be run on, else continue.
 
-For decision functions the key variable is ``decision_boolean`` which should be a pandas
-dataframe column which is True or False for the components in ``decide_comps`` based on
-the function's criteria. That column is an input to ``change_comptable_classifications``
+For decision functions, the key variable is ``decision_boolean``, which should be a pandas
+dataframe column that is True or False for the components in ``decide_comps`` based on
+the function's criteria. That column is an input to ``change_comptable_classifications``,
 which will update the component_table classifications, update the classification history
 in component_status_table, and update the component classification_tags. Components not
 in ``decide_comps`` retain their existing classifications and tags.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -100,7 +100,7 @@ make sure to output the denoised time series into a separate directory.
 
 The decision tree is the series of conditions through which each component is
 classified as accepted or rejected. The kundu tree (`--tree kundu`), used in Prantik
-Kundu's MEICA v2.7, is the classification process that has long
+Kundu's MEICA v2.5, is the classification process that has long
 been used by ``tedana`` and users have been generally content with the results. The
 kundu tree used multiple intersecting metrics and rankings to classify components.
 How these steps may interact on specific datasets is opaque. While there is a kappa

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -99,21 +99,21 @@ make sure to output the denoised time series into a separate directory.
 *************************************************************************************
 
 The decision tree is the series of conditions through which each component is
-classified as accepted or rejected. The kundu tree (`--tree kundu`)
-was used in Prantik Kundu's MEICA v2.7 is the classification process that has long
+classified as accepted or rejected. The kundu tree (`--tree kundu`), used in Prantik
+Kundu's MEICA v2.7, is the classification process that has long
 been used by ``tedana`` and users have been generally content with the results. The
-kundu tree used multiple intersecting metrics and rankings classify components.
+kundu tree used multiple intersecting metrics and rankings to classify components.
 How these steps may interact on specific datasets is opaque. While there is a kappa
 (T2*-weighted) elbow threshold and a rho (S0-weighted) elbow threshold, as discussed
 in publications, no component is accepted or rejected because of those thresholds.
-Users sometimes notice rejected components that clearly should been accepted. For
+Users sometimes notice rejected components that clearly should have been accepted. For
 example, a component that included a clear T2*-weighted V1 response to a block design
 flashing checkerboard was sometimes rejected because the relatively large variance of
 that component interacted with a rejection criterion.
 
 The minimal tree (`--tree minimal`) is designed to be easier to understand and less
-likely to reject T2* weighted components. There are a few other critiera, but components
-with `kappa>kappa elbow` and `rho<rho eblow` should all be accepted and the rho elbow
+likely to reject T2* weighted components. There are a few other criteria, but components
+with `kappa>kappa elbow` and `rho<rho elbow` should all be accepted, and the rho elbow
 threshold is less stringent. If kappa is above threshold and more than 2X rho then it
 is also accepted under the assumption that, even if a component contains noise, there
 is sufficient T2*-weighted signal to retain. Similarly to the kundu tree, components
@@ -122,17 +122,17 @@ removing them, but `minimal` makes sure that no more than 1% of total variance i
 removed this way.
 
 ``tedana`` developers still want to examine how the minimal tree performs on a wide
-range of datasets, but primary benefit is that it is possible to describe what it does
+range of datasets, but the primary benefit is that it is possible to describe what it does
 in a short paragraph. The minimal tree will retain some components that kundu
 appropriately classifies as noise, and it will reject some components that kundu
 accepts. On balance, we expect it to be a more conservative option that should not
-remove noise as agressively as kundu, but will be less likely to reject components that
+remove noise as aggressively as kundu, but will be less likely to reject components that
 clearly contain signal-of-interest.
 
 It is also possible for users to view both decision trees and `make their own`_.
 This might be useful for general methods development and also for using ``tedana``
-on multi-echo datasets with properties that differs from those these trees have been
-tested on (i.e. human whole-brain acqusitions). It is also possible, but a bit more
+on multi-echo datasets with properties different from those of the datasets these trees have been
+tested on (i.e. human whole-brain acquisitions). It is also possible, but a bit more
 challenging, to add additional metrics for each component so that the selection process
 can include additional criteria.
 
@@ -154,11 +154,11 @@ mostly be the same, but the results will not be identical.
 
 Prantik Kundu also worked on `MEICA v3.2`_ (also for python v2.7). The underlying ICA
 step is very similar, but the component selection process was different. While this
-new approach has potentialy useful ideas, the early ``tedana`` developers experienced
+new approach has potentially useful ideas, the early ``tedana`` developers experienced
 non-trivial component misclassifications and there were no publications that
-validated this method. That is why ``tedana`` replicated the established and valided
-MEICA v2.5 method and also includes options to ingrate additional component selection
-methods. Recently Prantik has started to work `MEICA v3.3`_ (for python >=v3.7) so
+validated this method. That is why ``tedana`` replicated the established and validated
+MEICA v2.5 method and also includes options to integrate additional component selection
+methods. Recently Prantik has started to work on `MEICA v3.3`_ (for python >=v3.7) so
 that this version of the selection process would again be possible to run.
 
 .. _shared code on bitbucket: https://bitbucket.org/prantikk/me-ica/src/experimental

--- a/tedana/workflows/t2smap.py
+++ b/tedana/workflows/t2smap.py
@@ -90,12 +90,14 @@ def _get_parser():
         dest="fittype",
         action="store",
         choices=["loglin", "curvefit"],
-        help="Desired Fitting Method"
-        '"loglin" means that a linear model is fit'
-        " to the log of the data, default"
-        '"curvefit" means that a more computationally'
-        "demanding monoexponential model is fit"
-        "to the raw data",
+        help=(
+            "Desired T2*/S0 fitting method. "
+            '"loglin" means that a linear model is fit '
+            "to the log of the data. "
+            '"curvefit" means that a more computationally '
+            "demanding monoexponential model is fit "
+            "to the raw data. "
+        ),
         default="loglin",
     )
     optional.add_argument(
@@ -130,7 +132,7 @@ def _get_parser():
             "threadpoolctl to set the parameter outside "
             "of the workflow function. Higher numbers of "
             "threads tend to slow down performance on "
-            "typical datasets. Default is 1."
+            "typical datasets."
         ),
         default=1,
     )

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -122,7 +122,6 @@ def _get_parser():
             '"curvefit" means that a more computationally '
             "demanding monoexponential model is fit "
             "to the raw data. "
-            'Default is "loglin".'
         ),
         default="loglin",
     )
@@ -131,7 +130,7 @@ def _get_parser():
         dest="combmode",
         action="store",
         choices=["t2s"],
-        help=("Combination scheme for TEs: t2s (Posse 1999, default)"),
+        help=("Combination scheme for TEs: t2s (Posse 1999)"),
         default="t2s",
     )
     optional.add_argument(
@@ -149,8 +148,9 @@ def _get_parser():
             "in which case components will be selected based on the "
             "cumulative variance explained or an integer greater than 1"
             "in which case the specificed number of components will be "
-            "selected. Default='aic'."
+            "selected."
         ),
+        choices=["mdl", "kic", "aic"],
         default="aic",
     )
     optional.add_argument(
@@ -174,7 +174,6 @@ def _get_parser():
             "algorithm. Set to an integer value for "
             "reproducible ICA results. Set to -1 for "
             "varying results across ICA calls. "
-            "Default=42."
         ),
         default=42,
     )
@@ -215,12 +214,12 @@ def _get_parser():
         nargs="+",
         help=(
             "Perform additional denoising to remove "
-            "spatially diffuse noise. Default is None. "
+            "spatially diffuse noise. "
             "This argument can be single value or a space "
             "delimited list"
         ),
         choices=["mir", "gsr"],
-        default=None,
+        default="",
     )
     optional.add_argument(
         "--no-reports",
@@ -265,7 +264,7 @@ def _get_parser():
             "threadpoolctl to set the parameter outside "
             "of the workflow function. Higher numbers of "
             "threads tend to slow down performance on "
-            "typical datasets. Default is 1."
+            "typical datasets."
         ),
         default=1,
     )
@@ -305,7 +304,7 @@ def _get_parser():
         "-f",
         dest="force",
         action="store_true",
-        help="Force overwriting of files. Default False.",
+        help="Force overwriting of files.", default=False,
     )
     optional.add_argument("-v", "--version", action="version", version=verstr)
     parser._action_groups.append(optional)


### PR DESCRIPTION
Changes proposed in this pull request:

- Minor grammar / spelling edits to 'Understanding and building a component selection process' and new FAQ sections
- Standardization of descriptions in 'Using tedana from the command line'
- One comment: tedana_reclassify is mentioned in FAQ but usage is not described in documentation. Should this be added to 'Using tedana from the command line'?
