### PR TITLE
Rename reclassify force

### DIFF
--- a/docs/classification_output_descriptions.rst
+++ b/docs/classification_output_descriptions.rst
@@ -59,7 +59,7 @@ and `classification_tags`. `classification` should include `accepted` or
 through denoising. `classification_tags` provide more information on why
 components received a specific classification. Each component can receive
 more than one tag. The following tags are included depending if ``--tree``
-is minimal, kundu, or if ``tedana_reclassify`` is run.
+is minimal, kundu, or if ``ica_reclassify`` is run.
 
 ===================== ================  ========================================
 Tag                   Included in Tree  Explanation

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -84,7 +84,7 @@ applying tedana, and you encounter this problem, please submit a question to `Ne
 [tedana] Can I manually reclassify components?
 ********************************************************************************
 
-``tedana_reclassify`` allows users to manually alter component classifications.
+``ica_reclassify`` allows users to manually alter component classifications.
 This can both be used as a command line tool or as part of other interactive
 programs, such as `RICA`_. RICA creates a graphical interface that is similar to
 the build-in tedana reports that lets users interactively change component

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ version = "0.0.12"
 [project.scripts]
 tedana = "tedana.workflows.tedana:_main"
 ica_reclassify = "tedana.workflows.ica_reclassify:_main"
+t2smap = "tedana.workflows.t2smap:_main"
 
 [build-system]
 requires = ["setuptools>=64", "wheel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.12"
 
 [project.scripts]
 tedana = "tedana.workflows.tedana:_main"
-tedana_reclassify = "tedana.workflows.tedana_reclassify:_main"
+ica_reclassify = "tedana.workflows.ica_reclassify:_main"
 
 [build-system]
 requires = ["setuptools>=64", "wheel"]

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -70,7 +70,7 @@ class OutputGenerator:
         descriptions. Default is "auto", which uses tedana's default configuration file.
     make_figures : bool, optional
         Whether or not to actually make a figures directory
-    force : bool, optional
+    overwrite : bool, optional
         Whether to force overwrites of data. Default False.
 
     Attributes
@@ -88,7 +88,7 @@ class OutputGenerator:
         This will correspond to a "figures" subfolder of ``out_dir``.
     prefix : str
         Prefix to prepend to output filenames.
-    force : bool
+    overwrite : bool
         Whether to force file overwrites.
     verbose : bool
         Whether or not to generate verbose output.
@@ -104,7 +104,7 @@ class OutputGenerator:
         prefix="",
         config="auto",
         make_figures=True,
-        force=False,
+        overwrite=False,
         verbose=False,
         old_registry=None,
     ):
@@ -132,7 +132,7 @@ class OutputGenerator:
         self.out_dir = op.abspath(out_dir)
         self.figures_dir = op.join(out_dir, "figures")
         self.prefix = prefix + "_" if prefix != "" else ""
-        self.force = force
+        self.overwrite = overwrite
         self.verbose = verbose
         self.registry = {}
         if old_registry:
@@ -252,11 +252,11 @@ class OutputGenerator:
             The full file path of the saved file.
         """
         name = self.get_name(description, **kwargs)
-        if op.exists(name) and not self.force:
+        if op.exists(name) and not self.overwrite:
             raise RuntimeError(
                 f"File {name} already exists. In order to allow overwrite "
-                "please use the --force option in the command line or the "
-                "force parameter in the Python API."
+                "please use the --overwrite option in the command line or the "
+                "overwrite parameter in the Python API."
             )
 
         if description.endswith("img"):

--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -21,7 +21,7 @@ from pkg_resources import resource_filename
 from tedana.io import InputHarvester
 from tedana.workflows import t2smap as t2smap_cli
 from tedana.workflows import tedana as tedana_cli
-from tedana.workflows.tedana_reclassify import post_tedana
+from tedana.workflows.ica_reclassify import post_tedana
 
 # Need to see if a no BOLD warning occurred
 LOGGER = logging.getLogger(__name__)
@@ -260,7 +260,7 @@ def test_integration_reclassify_insufficient_args(skip_integration):
     guarantee_reclassify_data()
 
     args = [
-        "tedana_reclassify",
+        "ica_reclassify",
         os.path.join(reclassify_raw(), "desc-tedana_registry.json"),
     ]
 
@@ -289,7 +289,7 @@ def test_integration_reclassify_quiet_csv(skip_integration):
     rej_df.to_csv(rej_csv_fname)
 
     args = [
-        "tedana_reclassify",
+        "ica_reclassify",
         "--manacc",
         acc_csv_fname,
         "--manrej",
@@ -315,7 +315,7 @@ def test_integration_reclassify_quiet_spaces(skip_integration):
         shutil.rmtree(out_dir)
 
     args = [
-        "tedana_reclassify",
+        "ica_reclassify",
         "--manacc",
         "1",
         "2",
@@ -345,7 +345,7 @@ def test_integration_reclassify_quiet_string(skip_integration):
         shutil.rmtree(out_dir)
 
     args = [
-        "tedana_reclassify",
+        "ica_reclassify",
         "--manacc",
         "1,2,3",
         "--manrej",
@@ -371,7 +371,7 @@ def test_integration_reclassify_debug(skip_integration):
         shutil.rmtree(out_dir)
 
     args = [
-        "tedana_reclassify",
+        "ica_reclassify",
         "--manacc",
         "1",
         "2",
@@ -435,7 +435,7 @@ def test_integration_reclassify_run_twice(skip_integration):
         reclassify_raw_registry(),
         accept=[1, 2, 3],
         out_dir=out_dir,
-        force=True,
+        overwrite=True,
         no_reports=True,
     )
     fn = resource_filename("tedana", "tests/data/reclassify_run_twice.txt")

--- a/tedana/workflows/ica_reclassify.py
+++ b/tedana/workflows/ica_reclassify.py
@@ -58,7 +58,7 @@ def _main():
     parser.add_argument(
         "--config",
         dest="config",
-        help="File naming configuration. Default auto (prepackaged).",
+        help="File naming configuration.",
         default="auto",
     )
     parser.add_argument(
@@ -124,7 +124,7 @@ def _main():
         "-f",
         dest="overwrite",
         action="store_true",
-        help="Force overwriting of files. Default False.",
+        help="Force overwriting of files.",
     )
     parser.add_argument(
         "--quiet", dest="quiet", help=argparse.SUPPRESS, action="store_true", default=False

--- a/tedana/workflows/ica_reclassify.py
+++ b/tedana/workflows/ica_reclassify.py
@@ -27,7 +27,7 @@ RepLGR = logging.getLogger("REPORT")
 def _main():
     from tedana import __version__
 
-    verstr = "tedana_reclassify v{}".format(__version__)
+    verstr = "ica_reclassify v{}".format(__version__)
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "registry",
@@ -120,9 +120,9 @@ def _main():
         default=False,
     )
     parser.add_argument(
-        "--force",
+        "--overwrite",
         "-f",
-        dest="force",
+        dest="overwrite",
         action="store_true",
         help="Force overwriting of files. Default False.",
     )
@@ -170,7 +170,7 @@ def _main():
         mir=args.mir,
         no_reports=args.no_reports,
         png_cmap=args.png_cmap,
-        force=args.force,
+        overwrite=args.overwrite,
         debug=args.debug,
         quiet=args.quiet,
     )
@@ -188,7 +188,7 @@ def post_tedana(
     mir=False,
     no_reports=False,
     png_cmap="coolwarm",
-    force=False,
+    overwrite=False,
     debug=False,
     quiet=False,
 ):
@@ -220,7 +220,7 @@ def post_tedana(
         Cannot be used with --no-png. Default is 'coolwarm'.
     debug : :obj:`bool`, optional
         Whether to run in debugging mode or not. Default is False.
-    force : :obj:`bool`, optional
+    overwrite : :obj:`bool`, optional
         Whether to force file overwrites. Default is False.
     quiet : :obj:`bool`, optional
         If True, suppresses logging/printing of messages. Default is False.
@@ -314,7 +314,7 @@ def post_tedana(
         convention=convention,
         prefix=prefix,
         config=config,
-        force=force,
+        overwrite=overwrite,
         verbose=False,
         out_dir=out_dir,
         old_registry=ioh.registry,
@@ -410,9 +410,9 @@ def post_tedana(
     )
 
     if mir:
-        io_generator.force = True
+        io_generator.overwrite = True
         gsc.minimum_image_regression(data_oc, mmix, mask_denoise, comptable, io_generator)
-        io_generator.force = False
+        io_generator.overwrite = False
 
     # Write out BIDS-compatible description file
     derivative_metadata = {
@@ -421,7 +421,7 @@ def post_tedana(
         "DatasetType": "derivative",
         "GeneratedBy": [
             {
-                "Name": "tedana_reclassify",
+                "Name": "ica_reclassify",
                 "Version": __version__,
                 "Description": (
                     "A denoising pipeline for the identification and removal "

--- a/tedana/workflows/ica_reclassify.py
+++ b/tedana/workflows/ica_reclassify.py
@@ -28,7 +28,7 @@ def _main():
     from tedana import __version__
 
     verstr = "ica_reclassify v{}".format(__version__)
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
         "registry",
         help="File registry from a previous tedana run",

--- a/tedana/workflows/t2smap.py
+++ b/tedana/workflows/t2smap.py
@@ -25,7 +25,7 @@ def _get_parser():
     -------
     parser.parse_args() : argparse dict
     """
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     # Argument parser follow templtate provided by RalphyZ
     # https://stackoverflow.com/a/43456577
     optional = parser._action_groups.pop()
@@ -119,7 +119,7 @@ def _get_parser():
         dest="combmode",
         action="store",
         choices=["t2s", "paid"],
-        help=("Combination scheme for TEs: t2s (Posse 1999, default), paid (Poser)"),
+        help=("Combination scheme for TEs: t2s (Posse 1999), paid (Poser)"),
         default="t2s",
     )
     optional.add_argument(

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -47,7 +47,7 @@ def _get_parser():
     from tedana import __version__
 
     verstr = "tedana v{}".format(__version__)
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     # Argument parser follow templtate provided by RalphyZ
     # https://stackoverflow.com/a/43456577
     optional = parser._action_groups.pop()

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -304,7 +304,8 @@ def _get_parser():
         "-f",
         dest="overwrite",
         action="store_true",
-        help="Force overwriting of files.", default=False,
+        help="Force overwriting of files.",
+        default=False,
     )
     optional.add_argument("-v", "--version", action="version", version=verstr)
     parser._action_groups.append(optional)

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -301,9 +301,9 @@ def _get_parser():
         "--quiet", dest="quiet", help=argparse.SUPPRESS, action="store_true", default=False
     )
     parser.add_argument(
-        "--force",
+        "--overwrite",
         "-f",
-        dest="force",
+        dest="overwrite",
         action="store_true",
         help="Force overwriting of files. Default False.",
     )
@@ -335,7 +335,7 @@ def tedana_workflow(
     low_mem=False,
     debug=False,
     quiet=False,
-    force=False,
+    overwrite=False,
     t2smap=None,
     mixm=None,
 ):
@@ -473,7 +473,7 @@ def tedana_workflow(
         out_dir=out_dir,
         prefix=prefix,
         config="auto",
-        force=force,
+        overwrite=overwrite,
         verbose=verbose,
     )
 
@@ -669,10 +669,10 @@ def tedana_workflow(
 
             # If we're going to restart, temporarily allow force overwrite
             if keep_restarting:
-                io_generator.force = True
+                io_generator.overwrite = True
             RepLGR.disabled = True  # Disable the report to avoid duplicate text
         RepLGR.disabled = False  # Re-enable the report after the while loop is escaped
-        io_generator.force = force  # Re-enable original overwrite behavior
+        io_generator.overwrite = overwrite  # Re-enable original overwrite behavior
     else:
         LGR.info("Using supplied mixing matrix from ICA")
         mixing_file = io_generator.get_name("ICA mixing tsv")


### PR DESCRIPTION
Changes proposed in this pull request:

- Changes --force to --overwrite in all parameters and CLI functions
- Changes tedana_reclassify to ica_reclassify
- Adds t2smap to project.toml so that it can be run from the CLI
- For CLI sets the argparse option to also show defaults when --help is used.
