### PR TITLE
Using a more persistent cache for the testing data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 docs/generated/
 .pytest_cache/
+.testing_data_cache/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ exclude = '''
     | \.github
     | \.hg
     | \.pytest_cache
+    | \.testing_data_cache
     | _build
     | build
     | dist

--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -27,6 +27,8 @@ from tedana.workflows.ica_reclassify import post_tedana
 
 # Need to see if a no BOLD warning occurred
 LOGGER = logging.getLogger(__name__)
+# Added a testing logger to output whether or not testing data were downlaoded
+TestLGR = logging.getLogger("TESTING")
 
 
 def check_integration_outputs(fname, outpath, n_logs=1):
@@ -140,8 +142,8 @@ def download_test_data(osfID, test_data_path):
                 f"Cannot access https://osf.io/{osfID} and testing data " "are not yet downloaded"
             )
         else:
-            print(
-                f"WARNING: Cannot access https://osf.io/{osfID}. "
+            TestLGR.warning(
+                f"Cannot access https://osf.io/{osfID}. "
                 f"Using local copy of testing data in {test_data_path} "
                 "but cannot validate that local copy is up-to-date"
             )
@@ -168,10 +170,12 @@ def download_test_data(osfID, test_data_path):
         local_data_exists = False
     if local_data_exists:
         if local_filedate_str == osf_filedate:
-            print(f"Downloaded and up-to-date data already in {test_data_path}. Not redownloading")
+            TestLGR.INFO(
+                f"Downloaded and up-to-date data already in {test_data_path}. Not redownloading"
+            )
             return
         else:
-            print(
+            TestLGR.INFO(
                 f"Downloaded data in {test_data_path} is older than data "
                 f"in https://osf.io/{osfID}. Deleting and redownloading"
             )

--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -176,8 +176,9 @@ def download_test_data(osfID, test_data_path):
             return
         else:
             TestLGR.INFO(
-                f"Downloaded data in {test_data_path} is older than data "
-                f"in https://osf.io/{osfID}. Deleting and redownloading"
+                f"Downloaded data in {test_data_path} was last modified on "
+                f"{local_filedate_str}. Data on https://osf.io/{osfID} "
+                f" was last updated on {osf_filedate}. Deleting and redownloading"
             )
             shutil.rmtree(test_data_path)
     req = requests.get(f"https://osf.io/{osfID}/download")


### PR DESCRIPTION
Changes proposed in this pull request:

- Cleans up how testing datasets are downloaded within test_integration.py. In Main & the current JT_DTM each dataset is downloaded in a slightly different way and the five-echo data are downloaded twice.
- I've added `data_for_testing_info` which gives the file hash location and local directory name for each of the four files we download. All tests are updated to use this function.
- The local copy of testing data will now go into the `.testing_data_cache` subdirectory (Is there another preferred location?)
  - The downloaded testing data will be in directories like `./testing_data_cache/three-echo` while the outputs from running tests will be in `./testing_data_cache/outputs/three-echo` This is done so that the directories with the downloaded data can be completely static and we can delete and recalculate the outputs without messing with anything in the downloaded directories
- When `download_test_data` is called, it will first download the metadata json to see if the last updated copy on osf.io is newer than the downloaded version and will only download if osf has a newer file. Downloading the metadata will happen frequently, but it will hopefully be fast.
  - The logger is now used to give a warning if osf.io cannot be accessed, but it will still run using cached data
