### PR TITLE
Improving ica_reclassify

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -24,6 +24,7 @@ API
    :toctree: generated/
 
    tedana.workflows.tedana_workflow
+   tedana.workflows.ica_reclassify_workflow
    tedana.workflows.t2smap_workflow
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -7,8 +7,8 @@ Using tedana from the command line
   #. Acquired echo times (in milliseconds)
   #. Functional datasets equal to the number of acquired echoes
 
-But you can supply many other options, viewable with ``tedana -h`` or
-``t2smap -h``.
+But you can supply many other options, viewable with ``tedana -h``,
+``ica_reclassify -h``, or ``t2smap -h``.
 
 For most use cases, we recommend that users call tedana from within existing
 fMRI preprocessing pipelines such as `fMRIPrep`_ or `afni_proc.py`_.
@@ -51,6 +51,22 @@ https://tedana.readthedocs.io/en/latest/outputs.html
     To examine regions-of-interest with multi-echo data, apply masks after TE
     Dependent ANAlysis.
 
+.. _ica_reclassify cli:
+
+***********************************
+Running the ica_reclassify workflow
+***********************************
+
+``ica_reclassify`` takes the output of ``tedana`` and can be used to manually
+reclassify components, re-save denoised classifications following the new
+classifications, and log the changes in all relevant output files. The
+output files are the same as for ``tedana``:
+https://tedana.readthedocs.io/en/latest/outputs.html
+
+.. argparse::
+   :ref: tedana.workflows.ica_reclassify._get_parser
+   :prog: ica_reclassify
+   :func: _get_parser
 
 .. _t2smap cli:
 

--- a/tedana/selection/selection_utils.py
+++ b/tedana/selection/selection_utils.py
@@ -815,7 +815,6 @@ def get_extend_factor(n_vols=None, extend_factor=None):
         LGR.info(f"extend_factor={extend_factor}, based on number of fMRI volumes")
     else:
         error_msg = "get_extend_factor need n_vols or extend_factor as an input"
-        LGR.error(error_msg)
         raise ValueError(error_msg)
 
     return extend_factor

--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -23,7 +23,7 @@ from pkg_resources import resource_filename
 from tedana.io import InputHarvester
 from tedana.workflows import t2smap as t2smap_cli
 from tedana.workflows import tedana as tedana_cli
-from tedana.workflows.ica_reclassify import post_tedana
+from tedana.workflows.ica_reclassify import ica_reclassify_workflow
 
 # Need to see if a no BOLD warning occurred
 LOGGER = logging.getLogger(__name__)
@@ -296,7 +296,7 @@ def test_integration_four_echo(skip_integration):
         verbose=True,
     )
 
-    post_tedana(
+    ica_reclassify_workflow(
         op.join(out_dir, "desc-tedana_registry.json"),
         accept=[1, 2, 3],
         reject=[4, 5, 6],
@@ -515,7 +515,7 @@ def test_integration_reclassify_both_rej_acc(skip_integration):
         ValueError,
         match=r"The following components were both accepted and",
     ):
-        post_tedana(
+        ica_reclassify_workflow(
             reclassify_raw_registry(),
             accept=[1, 2, 3],
             reject=[1, 2, 3],
@@ -532,13 +532,13 @@ def test_integration_reclassify_run_twice(skip_integration):
     if os.path.exists(out_dir):
         shutil.rmtree(out_dir)
 
-    post_tedana(
+    ica_reclassify_workflow(
         reclassify_raw_registry(),
         accept=[1, 2, 3],
         out_dir=out_dir,
         no_reports=True,
     )
-    post_tedana(
+    ica_reclassify_workflow(
         reclassify_raw_registry(),
         accept=[1, 2, 3],
         out_dir=out_dir,
@@ -562,7 +562,7 @@ def test_integration_reclassify_no_bold(skip_integration, caplog):
     comptable = ioh.get_file_contents("ICA metrics tsv")
     to_accept = [i for i in range(len(comptable))]
 
-    post_tedana(
+    ica_reclassify_workflow(
         reclassify_raw_registry(),
         reject=to_accept,
         out_dir=out_dir,
@@ -587,7 +587,7 @@ def test_integration_reclassify_accrej_files(skip_integration, caplog):
     comptable = ioh.get_file_contents("ICA metrics tsv")
     to_accept = [i for i in range(len(comptable))]
 
-    post_tedana(
+    ica_reclassify_workflow(
         reclassify_raw_registry(),
         reject=to_accept,
         out_dir=out_dir,

--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -599,6 +599,38 @@ def test_integration_reclassify_accrej_files(skip_integration, caplog):
     check_integration_outputs(fn, out_dir)
 
 
+def test_integration_reclassify_index_failures(skip_integration, caplog):
+    if skip_integration:
+        pytest.skip("Skip reclassify index failures")
+
+    test_data_path = guarantee_reclassify_data()
+    out_dir = os.path.abspath(os.path.join(test_data_path, "../outputs/reclassify/index_failures"))
+    if os.path.exists(out_dir):
+        shutil.rmtree(out_dir)
+
+    with pytest.raises(
+        ValueError,
+        match=r"_parse_manual_list expected a list of integers, but the input is",
+    ):
+        ica_reclassify_workflow(
+            reclassify_raw_registry(),
+            accept=[1, 2.5, 3],
+            out_dir=out_dir,
+            no_reports=True,
+        )
+
+    with pytest.raises(
+        ValueError,
+        match=r"_parse_manual_list expected integers or a filename, but the input is",
+    ):
+        ica_reclassify_workflow(
+            reclassify_raw_registry(),
+            accept=[2.5],
+            out_dir=out_dir,
+            no_reports=True,
+        )
+
+
 def test_integration_t2smap(skip_integration):
     """Integration test of the full t2smap workflow using five-echo test data"""
     if skip_integration:

--- a/tedana/workflows/__init__.py
+++ b/tedana/workflows/__init__.py
@@ -1,9 +1,9 @@
 # emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
 # ex: set sts=4 ts=4 sw=4 et:
-
+from .ica_reclassify import ica_reclassify_workflow
 from .t2smap import t2smap_workflow
 
 # Overrides submodules with their functions.
 from .tedana import tedana_workflow
 
-__all__ = ["tedana_workflow", "t2smap_workflow"]
+__all__ = ["tedana_workflow", "t2smap_workflow", "ica_reclassify_workflow"]

--- a/tedana/workflows/ica_reclassify.py
+++ b/tedana/workflows/ica_reclassify.py
@@ -24,16 +24,29 @@ LGR = logging.getLogger("GENERAL")
 RepLGR = logging.getLogger("REPORT")
 
 
-def _main():
+def _get_parser():
+    """
+    Parses command line inputs for tedana
+
+    Returns
+    -------
+    parser.parse_args() : argparse dict
+    """
+
     from tedana import __version__
 
     verstr = "ica_reclassify v{}".format(__version__)
+
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument(
+    # Argument parser follow templtate provided by RalphyZ
+    # https://stackoverflow.com/a/43456577
+    optional = parser._action_groups.pop()
+    required = parser.add_argument_group("Required Arguments")
+    required.add_argument(
         "registry",
         help="File registry from a previous tedana run",
     )
-    parser.add_argument(
+    optional.add_argument(
         "--manacc",
         dest="manual_accept",
         nargs="+",
@@ -43,8 +56,9 @@ def _main():
             "as a csv file, or as a text file with an allowed "
             f"delimiter {repr(ALLOWED_COMPONENT_DELIMITERS)}."
         ),
+        default=[],
     )
-    parser.add_argument(
+    optional.add_argument(
         "--manrej",
         dest="manual_reject",
         nargs="+",
@@ -54,14 +68,15 @@ def _main():
             "as a csv file, or as a text file with an allowed "
             f"delimiter {repr(ALLOWED_COMPONENT_DELIMITERS)}."
         ),
+        default=[],
     )
-    parser.add_argument(
+    optional.add_argument(
         "--config",
         dest="config",
         help="File naming configuration.",
         default="auto",
     )
-    parser.add_argument(
+    optional.add_argument(
         "--out-dir",
         dest="out_dir",
         type=str,
@@ -69,10 +84,10 @@ def _main():
         help="Output directory.",
         default=".",
     )
-    parser.add_argument(
+    optional.add_argument(
         "--prefix", dest="prefix", type=str, help="Prefix for filenames generated.", default=""
     )
-    parser.add_argument(
+    optional.add_argument(
         "--convention",
         dest="convention",
         action="store",
@@ -80,20 +95,21 @@ def _main():
         help=("Filenaming convention. bids will use the latest BIDS derivatives version."),
         default="bids",
     )
-    parser.add_argument(
+    optional.add_argument(
         "--tedort",
         dest="tedort",
         action="store_true",
         help=("Orthogonalize rejected components w.r.t. accepted components prior to denoising."),
         default=False,
     )
-    parser.add_argument(
+    optional.add_argument(
         "--mir",
         dest="mir",
         action="store_true",
         help="Run minimum image regression.",
+        default=False,
     )
-    parser.add_argument(
+    optional.add_argument(
         "--no-reports",
         dest="no_reports",
         action="store_true",
@@ -105,10 +121,10 @@ def _main():
         ),
         default=False,
     )
-    parser.add_argument(
+    optional.add_argument(
         "--png-cmap", dest="png_cmap", type=str, help="Colormap for figures", default="coolwarm"
     )
-    parser.add_argument(
+    optional.add_argument(
         "--debug",
         dest="debug",
         action="store_true",
@@ -119,46 +135,32 @@ def _main():
         ),
         default=False,
     )
-    parser.add_argument(
+    optional.add_argument(
         "--overwrite",
         "-f",
         dest="overwrite",
         action="store_true",
         help="Force overwriting of files.",
     )
-    parser.add_argument(
+    optional.add_argument(
         "--quiet", dest="quiet", help=argparse.SUPPRESS, action="store_true", default=False
     )
-    parser.add_argument("-v", "--version", action="version", version=verstr)
+    optional.add_argument("-v", "--version", action="version", version=verstr)
 
-    args = parser.parse_args()
+    parser._action_groups.append(optional)
+    return parser
 
-    if not args.manual_accept:
-        manual_accept = []
-    elif len(args.manual_accept) > 1:
-        # We should assume that this is a list of integers
-        manual_accept = [int(x) for x in args.manual_accept]
-    elif op.exists(args.manual_accept[0]):
-        # filename was given
-        manual_accept = fname_to_component_list(args.manual_accept[0])
-    else:
-        # arbitrary string was given, length of list is 1
-        manual_accept = str_to_component_list(args.manual_accept[0])
 
-    if not args.manual_reject:
-        manual_reject = []
-    elif len(args.manual_reject) > 1:
-        # We should assume that this is a list of integers
-        manual_reject = [int(x) for x in args.manual_reject]
-    elif op.exists(args.manual_reject[0]):
-        # filename was given
-        manual_reject = fname_to_component_list(args.manual_reject[0])
-    else:
-        # arbitrary string
-        manual_reject = str_to_component_list(args.manual_reject[0])
+def _main(argv=None):
+    """ica_reclassify entry point"""
 
-    # Run post-tedana
-    post_tedana(
+    args = _get_parser().parse_args(argv)
+
+    manual_accept = parse_manual_list(args.manual_accept)
+    manual_reject = parse_manual_list(args.manual_reject)
+
+    # Run ica_reclassify_workflow
+    ica_reclassify_workflow(
         args.registry,
         accept=manual_accept,
         reject=manual_reject,
@@ -176,7 +178,38 @@ def _main():
     )
 
 
-def post_tedana(
+def parse_manual_list(manual_list):
+    """
+    Parse the list of components to accept or reject into a list of integers
+
+    Parameters
+    ----------
+    manual_list: :obj:`str` :obj:`list[str]` or [] or None
+        String of integers separated by spaces, commas, or tabs
+        A file name for a file that contains integers
+
+    Returns
+    -------
+    manual_nums: :obj:`list[int]`
+        A list of integers or an empty list.
+
+    """
+    if not manual_list:
+        manual_nums = []
+    elif len(manual_list) > 1:
+        # We should assume that this is a list of integers
+        manual_nums = [int(x) for x in manual_list]
+    elif op.exists(manual_list[0]):
+        # filename was given
+        manual_nums = fname_to_component_list(manual_list[0])
+    else:
+        # arbitrary string was given, length of list is 1
+        manual_nums = str_to_component_list(manual_list[0])
+
+    return manual_nums
+
+
+def ica_reclassify_workflow(
     registry,
     accept=[],
     reject=[],

--- a/tedana/workflows/ica_reclassify.py
+++ b/tedana/workflows/ica_reclassify.py
@@ -190,18 +190,26 @@ def _parse_manual_list(manual_list):
     manual_nums: :obj:`list[int]`
         A list of integers or an empty list.
 
+    Note
+    ----
+    Do not need to check if integers are less than 0 or greater than the total
+    number of components here, because it is later checked in selectcomps2use
+    and a descriptive error message will appear there
     """
     if not manual_list:
         manual_nums = []
     elif len(manual_list) > 1:
         # We should assume that this is a list of integers
-        try:
-            manual_nums = [int(x) for x in manual_list]
-        except ValueError:
-            LGR.error(
-                f"_parse_manual_list expected a list of integers, but the input is {manual_nums}"
-            )
-    elif op.exists(manual_list[0]):
+        manual_nums = []
+        for x in manual_list:
+            if float(x) == int(x):
+                manual_nums.append(int(x))
+            else:
+                raise ValueError(
+                    "_parse_manual_list expected a list of integers, "
+                    f"but the input is {manual_list}"
+                )
+    elif op.exists(str(manual_list[0])):
         # filename was given
         manual_nums = fname_to_component_list(manual_list[0])
     elif type(manual_list[0]) == str:
@@ -211,8 +219,8 @@ def _parse_manual_list(manual_list):
         # Is a single integer and should remain a list with a single integer
         manual_nums = manual_list
     else:
-        LGR.error(
-            f"_parse_manual_list expected integers or a filename, but the input is {manual_nums}"
+        raise ValueError(
+            f"_parse_manual_list expected integers or a filename, but the input is {manual_list}"
         )
 
     return manual_nums

--- a/tedana/workflows/t2smap.py
+++ b/tedana/workflows/t2smap.py
@@ -26,7 +26,7 @@ def _get_parser():
     parser.parse_args() : argparse dict
     """
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    # Argument parser follow templtate provided by RalphyZ
+    # Argument parser follow template provided by RalphyZ
     # https://stackoverflow.com/a/43456577
     optional = parser._action_groups.pop()
     required = parser.add_argument_group("Required Arguments")

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -48,7 +48,7 @@ def _get_parser():
 
     verstr = "tedana v{}".format(__version__)
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    # Argument parser follow templtate provided by RalphyZ
+    # Argument parser follow template provided by RalphyZ
     # https://stackoverflow.com/a/43456577
     optional = parser._action_groups.pop()
     required = parser.add_argument_group("Required Arguments")


### PR DESCRIPTION
ica_reclassify needed to be added to several places in the documentation. This turned out to be harder than expected since the other two workflows were structured in a different way so that some documentation was automatically rendered.

Changes proposed in this pull request:

- `post_tedana` changed to `ica_reclassify_workflow` to have consistent naming with the other workflows
- `_get_parser()` function added to `ica_reclassify` to match the other workflows and render the documentation in `useage.rst` the same way
- Code to parse the list of components to accept or reject from a text string or file was repeated in the code and is now in a separate function `_parse_manual_list`
- `_parse_manual_list()` additional checks for invalid inputs and gives descriptive ValueError messages and `test_integration_reclassify_index_failures` added to test for new error conditions
- Now the CLI and API accept a file name in or a list of integers (Previously, just the CLI)