### PR TITLE
Drop Python 3.6 and 3.7 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,48 +7,26 @@ orbs:
   codecov: codecov/codecov@1.0.5
 jobs:
 
-  makeenv_37:
+  makeenv_38:
     docker:
       - image: continuumio/miniconda3
     working_directory: /tmp/src/tedana
     steps:
       - checkout
       - restore_cache:
-          key: conda-py37-v2-{{ checksum "pyproject.toml" }}
+          key: conda-py38-v2-{{ checksum "pyproject.toml" }}
       - run:
           name: Generate environment
           command: |
-            if [ ! -d /opt/conda/envs/tedana_py37 ]; then
-              conda create -yq -n tedana_py37 python=3.7
-              source activate tedana_py37
+            if [ ! -d /opt/conda/envs/tedana_py38 ]; then
+              conda create -yq -n tedana_py38 python=3.8
+              source activate tedana_py38
               pip install -e .[tests]
             fi
       - save_cache:
-          key: conda-py37-v2-{{ checksum "pyproject.toml" }}
+          key: conda-py38-v2-{{ checksum "pyproject.toml" }}
           paths:
-              - /opt/conda/envs/tedana_py37
-
-  unittest_37:
-    docker:
-      - image: continuumio/miniconda3
-    working_directory: /tmp/src/tedana
-    steps:
-      - checkout
-      - restore_cache:
-          key: conda-py37-v2-{{ checksum "pyproject.toml" }}
-      - run:
-          name: Running unit tests
-          command: |
-            apt-get update
-            apt-get install -y make
-            source activate tedana_py37  # depends on makeenv_37
-            make unittest
-            mkdir /tmp/src/coverage
-            mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.py37
-      - persist_to_workspace:
-          root: /tmp
-          paths:
-              - src/coverage/.coverage.py37
+              - /opt/conda/envs/tedana_py38
 
   unittest_38:
     docker:
@@ -59,26 +37,14 @@ jobs:
       - restore_cache:
           key: conda-py38-v2-{{ checksum "pyproject.toml" }}
       - run:
-          name: Generate environment
-          command: |
-            apt-get update
-            apt-get install -yqq make
-            if [ ! -d /opt/conda/envs/tedana_py38 ]; then
-              conda create -yq -n tedana_py38 python=3.8
-              source activate tedana_py38
-              pip install .[tests]
-            fi
-      - run:
           name: Running unit tests
           command: |
-            source activate tedana_py38
+            apt-get update
+            apt-get install -y make
+            source activate tedana_py38  # depends on makeenv_38
             make unittest
             mkdir /tmp/src/coverage
             mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.py38
-      - save_cache:
-          key: conda-py38-v2-{{ checksum "pyproject.toml" }}
-          paths:
-              - /opt/conda/envs/tedana_py38
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -152,7 +118,6 @@ jobs:
           paths:
               - src/coverage/.coverage.py310
 
-
   style_check:
     docker:
       - image: continuumio/miniconda3
@@ -160,13 +125,13 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: conda-py37-v2-{{ checksum "pyproject.toml" }}
+          key: conda-py38-v2-{{ checksum "pyproject.toml" }}
       - run:
           name: Style check
           command: |
             apt-get update
             apt-get install -yqq make
-            source activate tedana_py37  # depends on makeenv37
+            source activate tedana_py38  # depends on makeenv38
             make lint
 
   three-echo:
@@ -176,14 +141,14 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: conda-py37-v2-{{ checksum "pyproject.toml" }}
+          key: conda-py38-v2-{{ checksum "pyproject.toml" }}
       - run:
           name: Run integration tests
           no_output_timeout: 40m
           command: |
             apt-get update
             apt-get install -yqq make
-            source activate tedana_py37  # depends on makeenv_37
+            source activate tedana_py38  # depends on makeenv_38
             make three-echo
             mkdir /tmp/src/coverage
             mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.three-echo
@@ -201,14 +166,14 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: conda-py37-v2-{{ checksum "pyproject.toml" }}
+          key: conda-py38-v2-{{ checksum "pyproject.toml" }}
       - run:
           name: Run integration tests
           no_output_timeout: 40m
           command: |
             apt-get update
             apt-get install -yqq make
-            source activate tedana_py37  # depends on makeenv_37
+            source activate tedana_py38  # depends on makeenv_38
             make four-echo
             mkdir /tmp/src/coverage
             mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.four-echo
@@ -226,14 +191,14 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: conda-py37-v2-{{ checksum "pyproject.toml" }}
+          key: conda-py38-v2-{{ checksum "pyproject.toml" }}
       - run:
           name: Run integration tests
           no_output_timeout: 40m
           command: |
             apt-get update
             apt-get install -yqq make
-            source activate tedana_py37  # depends on makeenv_37
+            source activate tedana_py38  # depends on makeenv_38
             make five-echo
             mkdir /tmp/src/coverage
             mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.five-echo
@@ -251,14 +216,14 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: conda-py37-v2-{{ checksum "pyproject.toml" }}
+          key: conda-py38-v2-{{ checksum "pyproject.toml" }}
       - run:
           name: Run integration tests
           no_output_timeout: 40m
           command: |
             apt-get update
             apt-get install -yqq make
-            source activate tedana_py37  # depends on makeenv_37
+            source activate tedana_py38  # depends on makeenv_38
             make reclassify
             mkdir /tmp/src/coverage
             mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.reclassify
@@ -277,14 +242,14 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: conda-py37-v2-{{ checksum "pyproject.toml" }}
+          key: conda-py38-v2-{{ checksum "pyproject.toml" }}
       - run:
           name: Run integration tests
           no_output_timeout: 40m
           command: |
             apt-get update
             apt-get install -yqq make
-            source activate tedana_py37  # depends on makeenv_37
+            source activate tedana_py38  # depends on makeenv_38
             make t2smap
             mkdir /tmp/src/coverage
             mv /tmp/src/tedana/.coverage /tmp/src/coverage/.coverage.t2smap
@@ -304,13 +269,13 @@ jobs:
           at: /tmp
       - checkout
       - restore_cache:
-          key: conda-py37-v2-{{ checksum "pyproject.toml" }}
+          key: conda-py38-v2-{{ checksum "pyproject.toml" }}
       - run:
           name: Merge coverage files
           command: |
             apt-get update
             apt-get install -yqq curl
-            source activate tedana_py37  # depends on makeenv37
+            source activate tedana_py38  # depends on makeenv38
             cd /tmp/src/coverage/
             coverage combine
             coverage xml
@@ -323,34 +288,32 @@ workflows:
   version: 2.1
   build_test:
     jobs:
-      - makeenv_37
-      - unittest_37:
+      - makeenv_38
+      - unittest_38:
           requires:
-            - makeenv_37
+            - makeenv_38
       - style_check:
           requires:
-            - makeenv_37
+            - makeenv_38
       - three-echo:
           requires:
-            - makeenv_37
+            - makeenv_38
       - four-echo:
           requires:
-            - makeenv_37
+            - makeenv_38
       - five-echo:
           requires:
-            - makeenv_37
+            - makeenv_38
       - reclassify:
           requires:
-            - makeenv_37
+            - makeenv_38
       - t2smap:
           requires:
-            - makeenv_37
-      - unittest_38
+            - makeenv_38
       - unittest_39
       - unittest_310
       - merge_coverage:
           requires:
-            - unittest_37
             - unittest_38
             - unittest_39
             - unittest_310

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -41,14 +41,14 @@ ENV LANG="C.UTF-8" \
 
 RUN git clone https://github.com/me-ica/tedana.git /tedana
 
-RUN bash -c "conda create -yq --name tedana_py36 python=3.6 pip \
-    && source activate tedana_py36 \
+RUN bash -c "conda create -yq --name tedana_env python=3.8 pip \
+    && source activate tedana_env \
     && pip install /tedana[all] \
     && pip install ipython \
     && rm -rf ~/.cache/pip/* \
     && conda clean --all"
 
-RUN /opt/conda/envs/tedana_py36/bin/ipython profile create \
+RUN /opt/conda/envs/tedana_env/bin/ipython profile create \
     && sed -i 's/#c.InteractiveShellApp.extensions = \[\]/ \
                  c.InteractiveShellApp.extensions = \['\''autoreload'\''\]/g' \
                /root/.ipython/profile_default/ipython_config.py
@@ -57,7 +57,7 @@ RUN mkdir -p /tedana/dev_tools
 
 COPY ["./dev_tools", "/tedana/dev_tools"]
 
-RUN sed -i '$isource activate tedana_py36' $ND_ENTRYPOINT
+RUN sed -i '$isource activate tedana_env' $ND_ENTRYPOINT
 
 RUN sed -i '$isource /tedana/dev_tools/run_tests.sh' $ND_ENTRYPOINT
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you use `tedana`, please cite the following papers, as well as our [most rece
 ### Use `tedana` with your local Python environment
 
 You'll need to set up a working development environment to use `tedana`.
-To set up a local environment, you will need Python >=3.6 and the following packages will need to be installed:
+To set up a local environment, you will need Python >=3.8 and the following packages will need to be installed:
 
 * [numpy](http://www.numpy.org/)
 * [scipy](https://www.scipy.org/)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,7 +3,7 @@ Installation
 ############
 
 You'll need to set up a working development environment to use ``tedana``.
-To set up a local environment, you will need Python >=3.6 and the following
+To set up a local environment, you will need Python >=3.8 and the following
 packages will need to be installed:
 
 - nilearn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,12 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
 ]
 license = {file = "LICENSE"}
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "bokeh<2.3.0",
     "mapca>=0.0.3",
@@ -26,7 +25,7 @@ dependencies = [
     "nibabel>=2.5.1",
     "nilearn>=0.7",
     "numpy>=1.16",
-    "pandas>=0.24",
+    "pandas>=2.0",
     "scikit-learn>=0.21",
     "scipy>=1.2.0",
     "threadpoolctl",

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -342,7 +342,7 @@ class OutputGenerator:
 
         # Replace blanks with numpy NaN
         deblanked = data.replace("", np.nan)
-        deblanked.to_csv(name, sep="\t", line_terminator="\n", na_rep="n/a", index=False)
+        deblanked.to_csv(name, sep="\t", lineterminator="\n", na_rep="n/a", index=False)
 
     def save_self(self):
         fname = self.save_file(self.registry, "registry json")


### PR DESCRIPTION
Closes https://github.com/ME-ICA/tedana/issues/939 (I'll need to close manually).

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Drop 3.6 and 3.7 mentions, environments, tests, etc.
- Make pandas 2.0.0 the minimum version.
