### PR TITLE
Ica reclassify registry fixes

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -79,6 +79,11 @@
             "orcid": "0000-0002-2553-3327"
         },
         {
+            "name": "Molfese, Peter",
+            "affiliation": "National Institutes of Mental Health, CMN",
+            "orcid": "0000-0002-3045-9408"
+        },
+        {
             "name": "Salo, Taylor",
             "affiliation": "Florida International University",
             "orcid": "0000-0001-9813-3167"

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -339,55 +339,14 @@ class OutputGenerator:
         data_type = type(data)
         if not isinstance(data, pd.DataFrame):
             raise TypeError(f"data must be pd.Data, not type {data_type}.")
-
-        # Replace blanks with numpy NaN
-        deblanked = data.replace("", np.nan)
-        deblanked.to_csv(name, sep="\t", line_terminator="\n", na_rep="n/a", index=False)
-
-    def save_self(self):
-        fname = self.save_file(self.registry, "registry json")
-        return fname
-
-
-class InputHarvester:
-    """Class for turning a registry file into a lookup table to get previous data."""
-
-    loaders = {
-        "json": lambda f: load_json(f),
-        "tsv": lambda f: pd.read_csv(f, delimiter="\t"),
-        "img": lambda f: nib.load(f),
-    }
-
-    def __init__(self, path):
-        self._full_path = path
-        self._base_dir = op.dirname(path)
-        self._registry = load_json(path)
-
-    def get_file_path(self, description):
-        if description in self._registry.keys():
-            return op.join(self._base_dir, self._registry[description])
+        if versiontuple(pd.__version__) >= versiontuple("1.5.2"):
+            data.to_csv(name, sep="\t", lineterminator="\n", na_rep="n/a", index=False)
         else:
-            return None
+            data.to_csv(name, sep="\t", line_terminator="\n", na_rep="n/a", index=False)
 
-    def get_file_contents(self, description):
-        """Get file contents.
 
-        Notes
-        -----
-        Since we restrict to just these three types, this function should always return.
-        If more types are added, the loaders dict will need to be updated with an appropriate
-        loader.
-        """
-        for ftype, loader in InputHarvester.loaders.items():
-            if ftype in description:
-                return loader(self.get_file_path(description))
-
-    @property
-    def registry(self):
-        """The underlying file registry, including the root directory."""
-        d = self._registry
-        d["root"] = self._base_dir
-        return d
+def versiontuple(v):
+    return tuple(map(int, (v.split("."))))
 
 
 def get_fields(name):

--- a/tedana/io.py
+++ b/tedana/io.py
@@ -359,9 +359,9 @@ class InputHarvester:
     }
 
     def __init__(self, path):
-        self._full_path = path
-        self._base_dir = op.dirname(path)
-        self._registry = load_json(path)
+        self._full_path = op.abspath(path)
+        self._base_dir = op.dirname(self._full_path)
+        self._registry = load_json(self._full_path)
 
     def get_file_path(self, description):
         if description in self._registry.keys():

--- a/tedana/workflows/ica_reclassify.py
+++ b/tedana/workflows/ica_reclassify.py
@@ -199,7 +199,7 @@ def _parse_manual_list(manual_list):
     if not manual_list:
         manual_nums = []
     elif len(manual_list) > 1:
-        # We should assume that this is a list of integers
+        # Assume that this is a list of integers, but raise error if not
         manual_nums = []
         for x in manual_list:
             if float(x) == int(x):
@@ -209,9 +209,9 @@ def _parse_manual_list(manual_list):
                     "_parse_manual_list expected a list of integers, "
                     f"but the input is {manual_list}"
                 )
-    elif op.exists(str(manual_list[0])):
+    elif op.exists(op.expanduser(str(manual_list[0]).strip(" "))):
         # filename was given
-        manual_nums = fname_to_component_list(manual_list[0])
+        manual_nums = fname_to_component_list(op.expanduser(str(manual_list[0]).strip(" ")))
     elif type(manual_list[0]) == str:
         # arbitrary string was given, length of list is 1
         manual_nums = str_to_component_list(manual_list[0])

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -732,6 +732,10 @@ def tedana_workflow(
     mixing_df = pd.DataFrame(data=mmix, columns=comp_names)
     if not op.exists(io_generator.get_name("ICA mixing tsv")):
         io_generator.save_file(mixing_df, "ICA mixing tsv")
+    else:  # Make sure the relative path to the supplied mixing matrix is saved in the registry
+        io_generator.registry["ICA mixing tsv"] = op.basename(
+            io_generator.get_name("ICA mixing tsv")
+        )
     betas_oc = utils.unmask(computefeats2(data_oc, mmix, mask_denoise), mask_denoise)
     io_generator.save_file(betas_oc, "z-scored ICA components img")
 


### PR DESCRIPTION
With this PR and when https://github.com/ME-ICA/rica/pull/58 is merged into Rica, DTM branch works with Rica.

Changes proposed in this pull request:

- Merged in https://github.com/ME-ICA/tedana/pull/938 so the PR will line up with the current `main`
- If a mixing matrix is supplied to `tedana` it copied it over to the outputs, but didn't add the file to the registry. This caused problems with `ica_reclassify. Added a clause to `tedana.py` so that the file name will be in the registry. (The new clause is a bit ugly, but it's in a part of the code that is still a bit ugly)
- Identified an issue in `ica_reclassify` if a file name for accepted or rejected components has a `~` That is now expanded to the full path so the file can be identified and loaded.
