### PR TITLE
ReadTheDocs rendering fix

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+  configuration: docs/conf.py
 
 build:
   os: ubuntu-22.04
@@ -17,4 +17,3 @@ python:
       path: .
       extra_requirements:
         - doc
-  system_packages: true


### PR DESCRIPTION
When https://github.com/jbteves/tedana/pull/44 was merged, the documentation was not compiling based on something that might be a more general issue with RTD. @tsalo suggested the fix tried in this PR https://github.com/neurostuff/NiMARE/pull/797

Changes proposed in this pull request:

- the `system_packages: true` line in `.readthedocs.yml` is removed.