### PR TITLE
Update documentation

### DIFF
--- a/docs/building_decision_trees.rst
+++ b/docs/building_decision_trees.rst
@@ -310,7 +310,7 @@ properly execute.
 In :mod:`~tedana.selection.selection_nodes`,
 :func:`~tedana.selection.selection_nodes.manual_classify`,
 :func:`~tedana.selection.selection_nodes.dec_left_op_right`,
-and :func:`~tedana.selection.selection_nodes.calc_kappa_rho_elbows_kundu`
+and :func:`~tedana.selection.selection_nodes.calc_kappa_elbow`
 are good examples for how to meet these expectations.
 
 Create a dictionary called "outputs" that includes key fields that should be recorded.

--- a/docs/building_decision_trees.rst
+++ b/docs/building_decision_trees.rst
@@ -7,11 +7,11 @@ of the component selection process and people who are considering customizing
 their own decision tree or contributing to ``tedana`` code. We have tried to
 make this accessible, but it is long. If you just want to better understand
 what's in the outputs from ``tedana`` start with
-`classification output descriptions`_.
+:doc:`classification_output_descriptions`.
 
 ``tedana`` involves transforming data into components, currently via ICA, and then
 calculating metrics for each component. Each metric has one value per component that
-is stored in a component_table dataframe. This structure is then passed to a
+is stored in a ``component_table`` dataframe. This structure is then passed to a
 "decision tree" through which a series of binary choices categorize each component
 as **accepted** or **rejected**. The time series for the rejected components are
 regressed from the data in the `final denoising step`_.
@@ -22,14 +22,18 @@ trees needs to be slightly altered due to the nature of a specific data set, if 
 an idea for a new approach to multi-echo denoising, or if one wants to integrate
 non-multi-echo metrics into a single decision tree.
 
-Note: We use two terminologies interchangeably. The whole process is called "component
-selection" and much of the code uses variants of that phrase (i.e. the ComponentSelector
-class, selection_nodes for the functions used in selection). We call the steps for how
-to classify components a "decision tree" since each step in the selection process
-branches components into different intermediate or final classifications.
+.. note::
+  We use two terminologies interchangeably.
+  The whole process is called "component selection" and much of the code uses
+  variants of that phrase
+  (e.g. the :class:`~tedana.selection.component_selector.ComponentSelector` class,
+  :mod:`~tedana.selection.selection_nodes` for the functions used in selection).
+  We call the steps for how to classify components a "decision tree" since each
+  step in the selection process branches components into different intermediate
+  or final classifications.
 
-.. _classification output descriptions: classification_output_descriptions.html
 .. _final denoising step: denoising.html
+
 
 .. contents:: :local:
 
@@ -37,101 +41,101 @@ branches components into different intermediate or final classifications.
 Expected outputs after component selection
 ******************************************
 
-During processing, everything is stored in a `ComponentSelector object`_ called
-``selector``. The elements of that object are then saved to multiple files.
+During processing, everything is stored in a
+:class:`~tedana.selection.component_selector.ComponentSelector` called ``selector``.
+The elements of that object are then saved to multiple files.
 The file key names are used below the full file names in the
-`output file descriptions`_.
+:doc:`output_file_descriptions`.
 
-.. _ComponentSelector object: generated/tedana.selection.component_selector.ComponentSelector.html
-.. _output file descriptions: output_file_descriptions.html
 
-**General outputs from component selection**
+General outputs from component selection
+========================================
 
 New columns in ``selector.component_table`` and the "ICA metrics tsv" file:
 
-    classification:
-        While the decision table is running, there may also be intermediate
-        classification labels, but the final labels are expected to be
-        "accepted" or "rejected". There will be a warning if other labels remain.
-
-    classification_tags:
-        Human readable tags that explain why a classification was reached.
-        Each component can have no tags (an empty string or n/a), one tag,
-        or a comma separated list of tags. These tags may be useful parameters
-        for visualizing and reviewing results
+  - classification:
+    While the decision table is running, there may also be intermediate
+    classification labels, but the final labels are expected to be
+    "accepted" or "rejected". There will be a warning if other labels remain.
+  - classification_tags:
+    Human readable tags that explain why a classification was reached.
+    Each component can have no tags (an empty string or n/a), one tag,
+    or a comma separated list of tags. These tags may be useful parameters
+    for visualizing and reviewing results
 
 ``selector.cross_component_metrics`` and "ICA cross component metrics json":
-    A dictionary of metrics that are each a single value calculated across components,
-    for example, kappa and rho elbows. User or pre-defined scaling factors are
-    also stored here. Any constant that is used in the component classification
-    processes that isn't pre-defined in the decision tree file should be saved here.
+  A dictionary of metrics that are each a single value calculated across components,
+  for example, kappa and rho elbows. User or pre-defined scaling factors are
+  also stored here. Any constant that is used in the component classification
+  processes that isn't pre-defined in the decision tree file should be saved here.
 
 ``selector.component_status_table`` and "ICA status table tsv":
-    A table where each column lists the classification status of
-    each component after each node was run. Columns are only added
-    for runs where component statuses can change.
-    This is useful for understanding the classification
-    path of each component through the decision tree
+  A table where each column lists the classification status of
+  each component after each node was run. Columns are only added
+  for runs where component statuses can change.
+  This is useful for understanding the classification
+  path of each component through the decision tree
 
 ``selector.tree`` and "ICA decision tree json":
-    A copy of the inputted decision tree specification with an added "output" field
-    for each node. The output field (see next section) contains information about
-    what happened during execution. Of particular note, each output includes a list
-    of the metrics used within the node, "node_label", which is a (hopefully) human
-    readable brief description of the node's function and, for nodes where component
-    classifications can change, "n_false" & "n_true" list who many components
-    changed classifications. The inputted parameters include "if_true" and "if_false"
-    which specify what changes for each component. These fields can be used to
-    construct a visual flow chart or text-based summary of how classifications
-    changed for each run.
+  A copy of the inputted decision tree specification with an added "output" field
+  for each node. The output field (see next section) contains information about
+  what happened during execution. Of particular note, each output includes a list
+  of the metrics used within the node, "node_label", which is a (hopefully) human
+  readable brief description of the node's function and, for nodes where component
+  classifications can change, "n_false" & "n_true" list who many components
+  changed classifications. The inputted parameters include "if_true" and "if_false"
+  which specify what changes for each component. These fields can be used to
+  construct a visual flow chart or text-based summary of how classifications
+  changed for each run.
 
 ``selector.tree["used_metrics"]`` and a field in "ICA decision tree json":
-    A list of the metrics that were used in the decision tree. Everything in
-    ``used_metrics`` should be in either ``necessary_metrics`` or
-    ``generated_metrics`` If a used metric isn't in either, a warning message
-    will appear. This is a useful check that makes sure every metric used was
-    pre-specified.
+  A list of the metrics that were used in the decision tree. Everything in
+  ``used_metrics`` should be in either ``necessary_metrics`` or
+  ``generated_metrics`` If a used metric isn't in either, a warning message
+  will appear. This is a useful check that makes sure every metric used was
+  pre-specified.
 
 ``selector.tree["classification_tags"]`` and a field in "ICA decision tree json":
-    A list of the pre-specified classification tags that could be used in a decision tree.
-    Any reporting interface should use this field so that all possible tags are listed
-    even if a given tag is not used by any component by the end of the selection process.
+  A list of the pre-specified classification tags that could be used in a decision tree.
+  Any reporting interface should use this field so that all possible tags are listed
+  even if a given tag is not used by any component by the end of the selection process.
 
-.. _saved in multiple files: output_file_descriptions.html
 
-**Outputs of each decision tree step**
+Outputs of each decision tree step
+==================================
 
 "ICA decision tree json" includes all the information from the specified decision tree
 for each "node" or function call. For each node, there is an "outputs" subfield with
-information from when the tree was executed. Each outputs field includes:
+information from when the tree was executed.
+Each outputs field includes:
 
-decision_node_idx:
+- decision_node_idx
     The decision tree functions are run as part of an ordered list.
     This is the positional index (the location of the function in
     the list), starting with index 0.
 
-used_metrics:
+- used_metrics
     A list of the metrics used in a node of the decision tree
 
-used_cross_component_metrics:
+- used_cross_component_metrics
     A list of cross component metrics used in the node of a decision tree
 
-node_label:
+- node_label
     A brief label for what happens in this node that can be used in a decision
     tree summary table or flow chart.
 
-n_true, n_false:
+- n_true, n_false
     For decision tree (dec) functions, the number of components that were classified
     as true or false, respectively, in this decision tree step.
 
-calc_cross_comp_metrics:
+- calc_cross_comp_metrics
     For calculation (calc) functions, cross component metrics that were
     calculated in this function. When this is included, each of those
     metrics and the calculated values are also distinct keys in 'outputs'.
     While the cross component metrics table does not include where each component
     was calculated, that information is stored here.
 
-added_component_table_metrics:
+- added_component_table_metrics
     It is possible to add a new metric to the component table during the selection process.
     This is useful if a metric is to be calculated on a subset of components based on what
     happened during previous steps in the selection process. This is **not** recommended,
@@ -139,17 +143,14 @@ added_component_table_metrics:
     meica it is possible.
 
 
-
 **************************************
 Decision trees distributed with tedana
 **************************************
 
-Two decision trees are distributed with ``tedana``. 
-`Flow charts detailing these trees are here`_. It might be useful to
-look at these trees while reading how to develop a custom decision tree.
-
-
-.. _Flow charts detailing these trees are here: included_decision_trees.html
+Two decision trees are distributed with ``tedana``.
+These trees are documented in :doc:`included_decision_trees`.
+It might be useful to look at these trees while reading how to develop a custom
+decision tree.
 
 
 *******************************
@@ -170,50 +171,51 @@ non-ideal results for the current code. Some criteria will result in an error if
 violated, but more will just give a warning. If you are designing or editing a new
 tree, look carefully at the warnings.
 
-A decision tree can include two types of nodes or functions. All functions are currently
-in `selection_nodes.py`_
+A decision tree can include two types of nodes or functions.
+All functions are currently in :mod:`~tedana.selection.selection_nodes`.
 
 - A decision function will use existing metrics and potentially change the
   classification of the components based on those metrics. By convention, all
-  these functions begin with "dec"
+  these functions begin with "dec".
 - A calculation function will take existing metrics and calculate a value across
   components to be used for classification, for example the kappa and rho elbows.
-  By convention, all these functions begin with "calc"
+  By convention, all these functions begin with "calc".
 - Nothing prevents a function from both calculating new cross component values and
   applying those values in a decision step, but following this convention should
   hopefully make decision tree specifications easier to follow and results easier
   to interpret.
 
 .. _resources/decision_trees: https://github.com/ME-ICA/tedana/tree/main/tedana/resources/decision_trees
-.. _selection_nodes.py: https://github.com/ME-ICA/tedana/tree/main/tedana/selection/selection_nodes.py
 
-**General information fields**
+
+General information fields
+==========================
 
 There are several fields with general information. Some of these store general
 information that's useful for reporting results and others store information
 that is used to check whether results are plausible & can help avoid mistakes.
 
-  tree_id:
-      A descriptive name for the tree that will be logged.
+- tree_id
+    A descriptive name for the tree that will be logged.
 
-  info:
-      A brief description of the tree for info logging
+- info
+    A brief description of the tree for info logging
 
-  report:
-      A narrative description of the tree that could be used in report logging
+- report
+    A narrative description of the tree that could be used in report logging
 
-  refs:
-      Publications that should be referenced when this tree is used
+- refs
+    Publications that should be referenced when this tree is used
 
-  necessary_metrics:
-      A list of the necessary metrics in the component table that will be used
-      by the tree. If a metric doesn't exist then this will raise an error instead
-      of executing a tree. (Depending on future code development, this could
-      potentially be used to run ``tedana`` by specifying a decision tree and
-      metrics are calculated based on the contents of this field.) If a necessary
-      metric isn't used, there will be a warning.
+- necessary_metrics
+    A list of the necessary metrics in the component table that will be used
+    by the tree. If a metric doesn't exist then this will raise an error instead
+    of executing a tree. (Depending on future code development, this could
+    potentially be used to run ``tedana`` by specifying a decision tree and
+    metrics are calculated based on the contents of this field.) If a necessary
+    metric isn't used, there will be a warning.
 
-  generated_metrics:
+- generated_metrics
     An optional initial field. It lists metrics that are to be calculated as
     part of the decision tree's execution. This is used similarly to necessary_metrics
     except, since the decision tree starts before these metrics exist, it won't raise
@@ -222,23 +224,25 @@ that is used to check whether results are plausible & can help avoid mistakes.
     classifications. This does make interpretation of results more confusing, but, since
     this functionality was part of the kundu decision tree, it is included.
 
-  intermediate_classifications:
-      A list of intermediate classifications (i.e. "provisionalaccept",
-      "provisionalreject"). It is very important to pre-specify these because the code
-      will make sure only the default classifications ("accepted" "rejected"
-      "unclassified") and intermediate classifications are used in a tree. This prevents
-      someone from accidentially losing a component due to a spelling error or other
-      minor variation in a classification label.
+- intermediate_classifications
+    A list of intermediate classifications (i.e. "provisionalaccept",
+    "provisionalreject"). It is very important to pre-specify these because the code
+    will make sure only the default classifications ("accepted" "rejected"
+    "unclassified") and intermediate classifications are used in a tree. This prevents
+    someone from accidentially losing a component due to a spelling error or other
+    minor variation in a classification label.
 
-  classification_tags:
-      A list of acceptable classification tags (i.e. "Likely BOLD", "Unlikely BOLD",
-      "Low variance"). This will both be used to make sure only these tags are used in
-      the tree and allow programs that interact with the results to see all potential
-      tags in one place. Note: "Likely BOLD" is a required tag. If tedana is run and
-      none of the components include the "Likely BOLD" tag, then ICA will be repeated
-      with a different seed and then the selection process will repeat.
+- classification_tags
+    A list of acceptable classification tags (i.e. "Likely BOLD", "Unlikely BOLD",
+    "Low variance"). This will both be used to make sure only these tags are used in
+    the tree and allow programs that interact with the results to see all potential
+    tags in one place. Note: "Likely BOLD" is a required tag. If tedana is run and
+    none of the components include the "Likely BOLD" tag, then ICA will be repeated
+    with a different seed and then the selection process will repeat.
 
-**Nodes in the decision tree**
+
+Nodes in the decision tree
+==========================
 
 The "nodes" field is an ordered list of elements where each element defines a
 node in the decision tree. Each node contains the information to call a function.
@@ -255,53 +259,59 @@ classified as 'accepted' or 'rejected' by the time the tree is completed.
 
 There are several key fields for each node:
 
-- "functionname": The exact function name in `selection_nodes.py`_ that will be called.
+- "functionname": The exact function name in :mod:`~tedana.selection.selection_nodes` that will be called.
 - "parameters": Specifications of all required parameters for the function in functionname
 - "kwargs": Specifications for optional parameters for the function in functionname
 
-The only parameter that is used in all functions is "decidecomps", which is used to
+The only parameter that is used in all functions is ``decide_comps``, which is used to
 identify, based on their classifications, the components a function should be applied
 to. It can be a single classification, or a comma separated string of classifications.
-In addition to the intermediate and default ("accepted" "rejected" "unclassified")
+In addition to the intermediate and default ("accepted", "rejected", "unclassified")
 component classifications, this can be "all" for functions that should be applied to
 all components regardless of their classifications.
 
-Most decision functions also include "if_true" and "if_false", which specify how to change
+Most decision functions also include ``if_true`` and ``if_false``, which specify how to change
 the classification of each component based on whether a decision criterion is true
 or false. In addition to the default and intermediate classification options, this can
-also be "nochange" (i.e. For components where a>b is true, "reject". For components
-where a>b is false, "nochange"). The optional parameters "tag_if_true" and "tag_if_false"
-define the classification tags to be assigned to components. Currently, the only
-exceptions are "manual_classify" and "dec_classification_doesnt_exist" which use
-"new_classification" to designate the new component classification and "tag" (optional)
-to designate which classification tag to apply.
+also be "nochange"
+(e.g., for components where a>b is true, "reject", and for components where a>b is false, "nochange").
+The optional parameters ``tag_if_true`` and ``tag_if_false``
+define the classification tags to be assigned to components.
+Currently, the only exceptions are ``manual_classify`` and ``dec_classification_doesnt_exist``,
+which use ``new_classification`` to designate the new component classification and
+``tag`` (optional) to designate which classification tag to apply.
 
 There are several optional parameters (to include within "kwargs") in every decision
 tree function:
 
-- custom_node_label: A brief label for what happens in this node that can be used in
+- ``custom_node_label``: A brief label for what happens in this node that can be used in
   a decision tree summary table or flow chart. If custom_node_label is not not defined,
   then each function has default descriptive text.
-- log_extra_report, log_extra_info: Text for each function call is automatically placed
+- ``log_extra_report``, ``log_extra_info``: Text for each function call is automatically placed
   in the logger output. In addition to that text, the text in these these strings will
   also be included in the logger with the report or info codes respectively. These
   might be useful to give a narrative explanation of why a step was parameterized a
   certain way.
-- only_used_metrics: If true, this function will only return the names of the component
+- ``only_used_metrics``: If true, this function will only return the names of the component
   table metrics that will be used when this function is fully run. This can be used to
   identify all used metrics before running the decision tree.
 
-"_comments" can be used to add a longer explanation about what a node is doing. This
-will not be logged anywhere except in the tree, but may be useful to help explain the
+``"_comments"`` can be used to add a longer explanation about what a node is doing.
+This will not be logged anywhere except in the tree, but may be useful to help explain the
 purpose of a given node.
+
 
 ********************************
 Key parts of selection functions
 ********************************
 
 There are several expectations for selection functions that are necessary for them to
-properly execute. In `selection_nodes.py`_, ``manual_classify``, ``dec_left_op_right``,
-and ``calc_kappa_rho_elbows_kundu`` are good examples for how to meet these expectations.
+properly execute.
+In :mod:`~tedana.selection.selection_nodes`,
+:func:`~tedana.selection.selection_nodes.manual_classify`,
+:func:`~tedana.selection.selection_nodes.dec_left_op_right`,
+and :func:`~tedana.selection.selection_nodes.calc_kappa_rho_elbows_kundu`
+are good examples for how to meet these expectations.
 
 Create a dictionary called "outputs" that includes key fields that should be recorded.
 The following line should be at the end of each function to retain the output info:
@@ -332,7 +342,6 @@ specific dataset.
 Existing functions define ``function_name_idx = f"Step {selector.current_node_idx}: [text of function_name]``.
 This is used in logging and is cleaner to initialize near the top of each function.
 
-
 Each function has code that creates a default node label in ``outputs["node_label"]``.
 The default node label may be used in decision tree visualization so it should be
 relatively short. Within this section, if there is a user-provided custom_node_label,
@@ -344,9 +353,11 @@ and output a warning if the function overwrites an existing value
 Code that adds the text ``log_extra_info`` and ``log_extra_report`` into the appropriate
 logs (if they are provided by the user)
 
-After the above information is included, all functions will call ``selectcomps2use``,
+After the above information is included,
+all functions will call :func:`~tedana.selection.selection_utils.selectcomps2use`,
 which returns the components with classifications included in ``decide_comps``
-and then runs ``confirm_metrics_exist``, which is an added check to make sure the metrics
+and then runs :func:`~tedana.selection.selection_utils.confirm_metrics_exist`,
+which is an added check to make sure the metrics
 used by this function exist in the component table.
 
 Nearly every function has a clause like:
@@ -364,18 +375,21 @@ there's nothing for the function to be run on, else continue.
 
 For decision functions, the key variable is ``decision_boolean``, which should be a pandas
 dataframe column that is True or False for the components in ``decide_comps`` based on
-the function's criteria. That column is an input to ``change_comptable_classifications``,
+the function's criteria.
+That column is an input to :func:`~tedana.selection.selection_utils.change_comptable_classifications`,
 which will update the component_table classifications, update the classification history
 in component_status_table, and update the component classification_tags. Components not
 in ``decide_comps`` retain their existing classifications and tags.
-``change_comptable_classifications`` also returns and should assign values to
+:func:`~tedana.selection.selection_utils.change_comptable_classifications`
+also returns and should assign values to
 ``outputs["n_true"]`` and ``outputs["n_false"]``. These log how many components were
 identified as true or false within each function.
 
 For calculation functions, the calculated values should be added as a value/key pair to
-both ``selector.cross_component_metrics`` and ``outputs``
+both ``selector.cross_component_metrics`` and ``outputs``.
 
-``log_decision_tree_step`` puts the relevant info from the function call into the program's output log.
+:func:`~tedana.selection.selection_utils.log_decision_tree_step`
+puts the relevant info from the function call into the program's output log.
 
 Every function should end with:
 

--- a/docs/classification_output_descriptions.rst
+++ b/docs/classification_output_descriptions.rst
@@ -4,12 +4,11 @@ Classification output descriptions
 
 Tedana outputs multiple files that can be used to subsequent analyses and to
 better understand one's denoising results.
-In addition to the `descriptions of file names`_ this page explains the
+In addition to the :doc:`output_file_descriptions` this page explains the
 contents of several of those files in more detail.
-`Building decision trees`_ covers the full process, and not just the
+:doc:`building_decision_trees` covers the full process, and not just the
 descriptions of outputted files, in more detail.
 
-.. _Building decision trees: building_decision_trees.html
 
 TEDPCA codes
 ============
@@ -19,9 +18,10 @@ dataset. Without this step, the number of components would be one less than
 the number of volumes, many of those components would effectively be
 Gaussian noise and ICA would not reliably converge. Standard methods for data
 reduction use cost functions, like MDL, KIC, and AIC to estimate the variance
-that is just noise and remove the lowest variance components under that threshold.
-By default, ``tedana`` uses AIC. Of those three, AIC is the least agressive and
-will retain the most components.
+that is just noise and remove the lowest variance components under that
+threshold.
+By default, ``tedana`` uses AIC.
+Of those three, AIC is the least agressive and will retain the most components.
 
 ``Tedana`` includes additional `kundu` and `kundu-stabilize` approaches that
 identify and remove components that don't contain T2* or S0 signal and are more
@@ -50,16 +50,20 @@ ICA Classification Outputs
 ==========================
 
 The component table is stored in ``desc-tedana_metrics.tsv`` or
-``tedana_metrics.tsv``. Each row is a component number. Each column is a metric
-that is calculated for each component. Short descriptions of each column metric
-are in the output log, ``tedana_[date_time].tsv``, and the actual metric
-calculations are in `collect.py`_ The final two columns are `classification`
-and `classification_tags`. `classification` should include `accepted` or
-`rejected` for every component and `rejected` components are be removed
-through denoising. `classification_tags` provide more information on why
-components received a specific classification. Each component can receive
-more than one tag. The following tags are included depending if ``--tree``
-is minimal, kundu, or if ``ica_reclassify`` is run.
+``tedana_metrics.tsv``.
+Each row is a component number.
+Each column is a metric that is calculated for each component.
+Short descriptions of each column metric are in the output log,
+``tedana_[date_time].tsv``, and the actual metric calculations are in
+:mod:`~tedana.metrics.collect`.
+The final two columns are ``classification`` and ``classification_tags``.
+``classification`` should include **accepted** or **rejected** for every
+component and **rejected** components are be removed through denoising.
+``classification_tags`` provide more information on why
+components received a specific classification.
+Each component can receive more than one tag.
+The following tags are included depending if ``--tree`` is "minimal", "kundu",
+or if ``ica_reclassify`` is run.
 
 ===================== ================  ========================================
 Tag                   Included in Tree  Explanation
@@ -93,13 +97,12 @@ in several places:
 
 - The information in the output log includes the name of each
   node and the count of components that changed classification during execution.
-- The same information is stored in the `ICA decision tree` json file (see
-  `descriptions of file names`_) in the "output" field for each node. That information
-  is organized so that it can be used to generate a visual or text-based summary of
-  what happened when the decision tree was run on a dataset.
-- The `ICA status table` lists the classification status of each component after
-  each node was run. This is particularly useful to trying to understand how a
-  specific component ended receiving its classification.
-
-.. _collect.py: https://github.com/ME-ICA/tedana/blob/main/tedana/metrics/collect.py
-.. _descriptions of file names: output_file_descriptions.html
+- The same information is stored in the ``ICA decision tree`` json file
+  (see :doc:`output_file_descriptions`) in the "output" field for each node.
+  That information is organized so that it can be used to generate a visual or
+  text-based summary of what happened when the decision tree was run on a
+  dataset.
+- The ``ICA status table`` lists the classification status of each component
+  after each node was run.
+  This is particularly useful to trying to understand how a specific component
+  ended receiving its classification.

--- a/docs/included_decision_trees.rst
+++ b/docs/included_decision_trees.rst
@@ -3,31 +3,33 @@ Included Decision Trees
 #######################
 
 Two decision trees are currently distributed with ``tedana``.
+
 ``kundu`` is the decision tree that is based on MEICA version 2.5
 and has been included with ``tedana`` since the start of this project.
 While multiple publications have used and benefits from this decision,
 tree, but it includes many steps with arbitrary thresholds and, when
 components seem misclassified, it's often hard to understand why.
+
 ``minimal`` is a simplified version of that decision tree with fewer
 steps and arbitrary thresholds. Minimal is designed to be more stable
 and comprehensible, but it has not yet be extensively validated and
 parts of the tree may change in response to additional tests on a
-wider range of data sets. 
+wider range of data sets.
 
 Flowcharts describing the steps in both trees are below.
-As documented more in `Building Decision Trees`_, the input to each tree
+As documented more in :doc:`building_decision_trees`, the input to each tree
 is a table with metrics, like :math:`\kappa` or :math:`\rho`, for each
 component. Each step or node in the decision tree either calculates
 new values or changes component classifications based on these metrics.
-When a component classification changes to `accept` or `reject`, a
-`classification_tag` is also assigned which may help understand why
+When a component classification changes to ``accept`` or ``reject``, a
+``classification_tag`` is also assigned which may help understand why
 a component was given a specific classification.
 
 Each step in the flow chart is labeled with a ``node`` number.
 If ``tedana`` is run using one of these trees, those node
 numbers will match the numbers in the ``ICA status table`` and the
-``ICA decision tree`` that are `saved with the outputs`_. These node
-numbers can be used to see when in the process a component's
+``ICA decision tree`` that are :doc:`output_file_descriptions`.
+These node numbers can be used to see when in the process a component's
 classifiation changed.
 
 .. image:: _static/decision_tree_legend.png
@@ -40,8 +42,6 @@ classifiation changed.
 
         <img src = "_static/decision_tree_legend.svg" alt="Legend for Decision Tree Flow Charts"/>
 
-.. _saved with the outputs: output_file_descriptions.html
-.. _Building Decision Trees: building_decision_trees.html
 
 *******************
 Kundu decision tree
@@ -54,8 +54,8 @@ elbow are classified as `provisional accept`. A non-obvious aspect
 of this decision tree is that no decision node below this point distinguishes
 components that are `provisional accept` from components that are still
 `unclassified` and nothing that does not cross the :math:`\kappa` and
-:math:`\rho` elbow thresholds is inherantly rejected. The number of 
-`provisional accept` components is used to see if the process should 
+:math:`\rho` elbow thresholds is inherantly rejected. The number of
+`provisional accept` components is used to see if the process should
 be restarted (node 11) and calculate other thresholds (nodes 12-16 & 20),
 but nothing is directly accepted or rejected based on the elbow thresholds.
 Several additional criteria are used to reject components (nodes 17, 21, & 22).
@@ -87,7 +87,7 @@ The only expection to this is if :math:`\kappa` > :math:`\kappa` elbow and
 the component should not be rejected even if it also contains noise (node 9).
 If `provisional reject` components have very low variance they are accepted rather
 than losing degrees of freedom, but no more than 1% of the total variance can be
-accepted this way (node 11). After that point, everything that is 
+accepted this way (node 11). After that point, everything that is
 `provisional accept` is accepted (node 12) and everything that is `provisional reject`
 is rejected (node 13)
 

--- a/docs/output_file_descriptions.rst
+++ b/docs/output_file_descriptions.rst
@@ -3,11 +3,11 @@ Output file name descriptions
 #############################
 
 tedana allows for multiple file naming conventions. The key labels and naming options for
-each convention that can be set using the `--convention` option are in `outputs.json`_.
-The output of `tedana` also includes a file called `registry.json` or
-`desc-tedana_registry.json` that includes the keys and the matching file names for the
-output. The table below lists both these keys and the default "BIDS Derivatives"
-file names.
+each convention that can be set using the ``--convention`` option are in `outputs.json`_.
+The output of ``tedana`` also includes a file called ``registry.json`` or
+``desc-tedana_registry.json`` that includes the keys and the matching file names for the
+output.
+The table below lists both these keys and the default "BIDS Derivatives" file names.
 
 .. _outputs.json: https://github.com/ME-ICA/tedana/blob/main/tedana/resources/config/outputs.json
 


### PR DESCRIPTION
Tagging @handwerkerd for your review.

For the most part, my changes just leverage restructuredText (e.g., by using the `:doc:` role instead of explicit hyperlinks). I think the documentation looks great, although one thing I don't like is splitting off the output filename documentation from the general output documentation. From the perspective of a user, I think being able to look at a list of files and seeing what each means is more immediately useful than a walkthrough of the HTML report, or really anything else on the main outputs page.